### PR TITLE
Migrate to @Observable macro

### DIFF
--- a/Solstice/ContentView.swift
+++ b/Solstice/ContentView.swift
@@ -22,7 +22,7 @@ struct ContentView: View {
 	@SceneStorage("selectedLocation") private var selectedLocation: String?
 	
 	@Environment(\.scenePhase) private var scenePhase
-	@EnvironmentObject var currentLocation: CurrentLocation
+	@Environment(CurrentLocation.self) var currentLocation
 	
 	@StateObject var locationSearchService = LocationSearchService()
 	
@@ -157,6 +157,6 @@ struct ContentView: View {
 	ContentView()
 		.environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
 		.withTimeMachine(.solsticeTimeMachine)
-		.environmentObject(CurrentLocation())
+		.environment(CurrentLocation())
 }
 

--- a/Solstice/Detail View/DetailView.swift
+++ b/Solstice/Detail View/DetailView.swift
@@ -18,7 +18,7 @@ struct DetailView<Location: ObservableLocation>: View {
 	@Environment(\.managedObjectContext) var viewContext
 	@Environment(\.dismiss) var dismiss
 	
-	@ObservedObject var location: Location
+	var location: Location
 	@Environment(\.timeMachine) var timeMachine: TimeMachine
 	#if !os(watchOS)
 	@EnvironmentObject var locationSearchService: LocationSearchService

--- a/Solstice/Helper Views/LandingView.swift
+++ b/Solstice/Helper Views/LandingView.swift
@@ -30,7 +30,7 @@ fileprivate extension View {
 struct LandingView: View {
 	@Environment(\.dynamicTypeSize) private var dynamicTypeSize
 	@Environment(\.dismiss) private var dismiss
-	@EnvironmentObject private var currentLocation: CurrentLocation
+	@Environment(CurrentLocation.self) private var currentLocation
 	@AppStorage(Preferences.hasCompletedOnboarding) private var hasCompletedOnboarding
 	@State private var animate = false
 	
@@ -134,7 +134,7 @@ struct LandingView: View {
 
 fileprivate struct WithOnboardingViewModifier: ViewModifier {
 	@AppStorage(Preferences.hasCompletedOnboarding) private var hasCompletedOnboarding
-	@EnvironmentObject private var currentLocation: CurrentLocation
+	@Environment(CurrentLocation.self) private var currentLocation
 	
 	@State private var shouldPresentOnboarding = false
 	

--- a/Solstice/Helpers/AnyLocation.swift
+++ b/Solstice/Helpers/AnyLocation.swift
@@ -17,7 +17,7 @@ protocol AnyLocation: Hashable {
 	var longitude: Double { get }
 }
 
-protocol ObservableLocation: AnyLocation, ObservableObject { }
+protocol ObservableLocation: AnyLocation, AnyObject { }
 
 extension AnyLocation {
 	var timeZone: TimeZone {
@@ -36,12 +36,13 @@ extension AnyLocation {
 
 extension SavedLocation: ObservableLocation { }
 
+@Observable
 class TemporaryLocation: ObservableLocation {
-	@Published var title: String?
-	@Published var subtitle: String?
-	@Published var timeZoneIdentifier: String?
-	@Published var latitude: Double = 0.0
-	@Published var longitude: Double = 0.0
+	var title: String?
+	var subtitle: String?
+	var timeZoneIdentifier: String?
+	var latitude: Double = 0.0
+	var longitude: Double = 0.0
 	
 	init(title: String?, subtitle: String?, timeZoneIdentifier: String?, latitude: Double, longitude: Double) {
 		self.title = title

--- a/Solstice/Helpers/CurrentLocation.swift
+++ b/Solstice/Helpers/CurrentLocation.swift
@@ -7,10 +7,10 @@
 
 import CoreLocation
 import SwiftUI
-import Combine
 
-class CurrentLocation: NSObject, ObservableObject, CLLocationManagerDelegate {
-	@Published private(set) var placemark: CLPlacemark?
+@Observable
+class CurrentLocation: NSObject, CLLocationManagerDelegate {
+	private(set) var placemark: CLPlacemark?
 	
 	private(set) var location: CLLocation? {
 		didSet {
@@ -21,8 +21,8 @@ class CurrentLocation: NSObject, ObservableObject, CLLocationManagerDelegate {
 		}
 	}
 	
-	private let locationManager = CLLocationManager()
-	private let geocoder = CLGeocoder()
+	@ObservationIgnored private let locationManager = CLLocationManager()
+	@ObservationIgnored private let geocoder = CLGeocoder()
 	
 	override init() {
 		super.init()

--- a/Solstice/List View/SidebarListView.swift
+++ b/Solstice/List View/SidebarListView.swift
@@ -11,7 +11,7 @@ import TimeMachine
 
 struct SidebarListView: View {
 	@AppStorage(Preferences.listViewAppearance) private var appearance
-	@EnvironmentObject var currentLocation: CurrentLocation
+	@Environment(CurrentLocation.self) var currentLocation
 	@Environment(\.timeMachine) var timeMachine: TimeMachine
 	@EnvironmentObject var locationSearchService: LocationSearchService
 	
@@ -178,7 +178,7 @@ struct SidebarListView_Previews: PreviewProvider {
 		}
 			.environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
 			.withTimeMachine(.solsticeTimeMachine)
-			.environmentObject(CurrentLocation())
+			.environment(CurrentLocation())
 	}
 }
 

--- a/Solstice/Settings/NotificationSettings.swift
+++ b/Solstice/Settings/NotificationSettings.swift
@@ -28,7 +28,7 @@ struct NotificationSettings: View {
 	
 	@AppStorage(Preferences.sadPreference) var sadPreference
 	
-	@EnvironmentObject var currentLocation: CurrentLocation
+	@Environment(CurrentLocation.self) var currentLocation
 	
 	@FetchRequest(
 		sortDescriptors: [NSSortDescriptor(keyPath: \SavedLocation.title, ascending: true)],

--- a/Solstice/Settings/SettingsView.swift
+++ b/Solstice/Settings/SettingsView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SettingsView: View {
 	@Environment(\.dismiss) private var dismiss
 	@Environment(\.openURL) private var openURL
-	@EnvironmentObject private var currentLocation: CurrentLocation
+	@Environment(CurrentLocation.self) private var currentLocation
 	
 	@AppStorage(Preferences.timeTravelAppearance) private var timeTravelAppearance
 	@AppStorage(Preferences.chartType) private var chartType

--- a/Solstice/SolsticeApp.swift
+++ b/Solstice/SolsticeApp.swift
@@ -13,7 +13,7 @@ import TimeMachine
 @main
 struct SolsticeApp: App {
 	@Environment(\.scenePhase) var phase
-	@StateObject private var currentLocation = CurrentLocation()
+	@State private var currentLocation = CurrentLocation()
 	@StateObject private var locationSearchService = LocationSearchService()
 
 	private let persistenceController = PersistenceController.shared
@@ -22,7 +22,7 @@ struct SolsticeApp: App {
 		WindowGroup {
 			ContentView()
 				.withAppOnboarding()
-				.environmentObject(currentLocation)
+				.environment(currentLocation)
 				.withTimeMachine(.solsticeTimeMachine)
 				.environmentObject(locationSearchService)
 				.task {
@@ -65,7 +65,7 @@ struct SolsticeApp: App {
 		#if os(visionOS)
 		WindowGroup(id: "settings") {
 			SettingsView()
-				.environmentObject(currentLocation)
+				.environment(currentLocation)
 		}
 		.defaultSize(width: 600, height: 600)
 		
@@ -82,7 +82,7 @@ struct SolsticeApp: App {
 			SettingsView()
 				.frame(maxWidth: 500)
 				.environment(\.managedObjectContext, persistenceController.container.viewContext)
-				.environmentObject(currentLocation)
+				.environment(currentLocation)
 		}
 		
 		Window("About solstices and equinoxes", id: "about-equinox-and-solstice") {

--- a/watchOS/ContentView.swift
+++ b/watchOS/ContentView.swift
@@ -11,7 +11,7 @@ import TimeMachine
 
 struct ContentView: View {
 	@Environment(\.scenePhase) var scenePhase
-	@EnvironmentObject var currentLocation: CurrentLocation
+	@Environment(CurrentLocation.self) var currentLocation
 	@Environment(\.timeMachine) var timeMachine: TimeMachine
 	
 	@SceneStorage("selectedLocation") private var selectedLocation: String?
@@ -110,5 +110,5 @@ struct ContentView: View {
 #Preview {
 	ContentView()
 		.withTimeMachine(.solsticeTimeMachine)
-		.environmentObject(CurrentLocation())
+		.environment(CurrentLocation())
 }


### PR DESCRIPTION
## Summary
Migrate from `ObservableObject` to the modern `@Observable` macro (iOS 17+) for better performance and cleaner SwiftUI code.

## Problem
The list view wasn't updating the current location's title/subtitle when the placemark changed. This was because views using `var location: Location` weren't properly observing changes to `CurrentLocation`'s published properties.

## Solution
Adopt the `@Observable` macro which provides:
- **Automatic property tracking**: SwiftUI only re-renders views when properties actually read in `body` change
- **Less boilerplate**: No need for `@Published`, `@ObservedObject`, or `@StateObject` wrappers
- **Better performance**: Eliminates unnecessary re-renders from unrelated property changes

## Changes

### Type Updates
| Type | Change |
|------|--------|
| `CurrentLocation` | Added `@Observable`, removed `ObservableObject`/`@Published` |
| `TemporaryLocation` | Added `@Observable`, removed `@Published` |
| `ObservableLocation` protocol | Changed from `ObservableObject` to `AnyObject` |

### Property Wrapper Updates
| Old Pattern | New Pattern |
|-------------|-------------|
| `@StateObject var currentLocation` | `@State var currentLocation` |
| `@EnvironmentObject var currentLocation` | `@Environment(CurrentLocation.self) var currentLocation` |
| `@ObservedObject var location` | `var location` |
| `.environmentObject(currentLocation)` | `.environment(currentLocation)` |

## Files Changed
- `Solstice/Helpers/CurrentLocation.swift`
- `Solstice/Helpers/AnyLocation.swift`
- `Solstice/SolsticeApp.swift`
- `Solstice/ContentView.swift`
- `Solstice/Detail View/DetailView.swift`
- `Solstice/List View/SidebarListView.swift`
- `Solstice/Settings/SettingsView.swift`
- `Solstice/Settings/NotificationSettings.swift`
- `Solstice/Helper Views/LandingView.swift`
- `watchOS/ContentView.swift`

🤖 Generated with [Claude Code](https://claude.ai/code)