### PR TITLE
fix(chart): keep sun marker on the path in RTL locales

### DIFF
--- a/Solstice/Charts/DaylightChart.swift
+++ b/Solstice/Charts/DaylightChart.swift
@@ -136,6 +136,14 @@ struct DaylightChart: View {
 				chartOverlayContent(proxy: proxy, geo: geo)
 			}
 		}
+		// Plot the chart left-to-right in every locale. The sun marker, scrub
+		// indicator, and drag hit-testing are positioned manually via
+		// `ChartProxy.position(forX:)` in an LTR coordinate space, but SwiftUI
+		// Charts auto-mirrors the line, points, and axis under RTL locales. That
+		// mismatch left the sun detached from the path (e.g. in Arabic). Pinning
+		// the plot to LTR keeps the native marks and the overlay in one coordinate
+		// system; the summary title and surrounding UI still follow the locale.
+		.environment(\.layoutDirection, .leftToRight)
 		.animation(timeMachine.isActive ? nil : .smooth(duration: 0.5), value: solar.date)
 		.onAppear {
 			sunDisplayOffset = plotOffset


### PR DESCRIPTION
The daylight chart positions the sun marker, scrub indicator, and drag
hit-testing manually via ChartProxy.position(forX:) in a left-to-right
GeometryReader coordinate space. Under RTL locales (e.g. Arabic), SwiftUI
Charts auto-mirrors the line, event points, and x-axis, but the manual
overlay stayed in its LTR position — leaving the sun detached from the
curve, hovering over the morning slope instead of sitting on the path.

Pin the chart's plot to a left-to-right layout direction so the native
marks and the overlay share one coordinate system. The summary title and
surrounding UI continue to follow the locale's layout direction.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AL8XQD3yCUVnf9qYTYFB4f