### PR TITLE
macOS tabbed Settings, About sheet fix, iPad focus halo, l10n

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -1396,6 +1396,64 @@
         }
       }
     },
+    "About" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "حول"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Info"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Información"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "À propos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Informazioni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "情報"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Info"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "O aplikacji"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "关于"
+          }
+        }
+      }
+    },
     "About Solstice" : {
       "localizations" : {
         "ar" : {
@@ -4184,6 +4242,64 @@
           "stringUnit" : {
             "state" : "machine_translated",
             "value" : "降序"
+          }
+        }
+      }
+    },
+    "Done" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "تم"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Fertig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "OK"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "OK"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Fine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "完了"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Gereed"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Gotowe"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "完成"
           }
         }
       }

--- a/Solstice/List View/GraphicalLocationListRow.swift
+++ b/Solstice/List View/GraphicalLocationListRow.swift
@@ -27,11 +27,67 @@ struct GraphicalLocationListRow<Location: ObservableLocation>: View {
 				solar?.view
 					.clipShape(.rect(cornerRadius: 20, style: .continuous))
 			}
+		#if os(iOS)
+			.background { FocusHaloShape(cornerRadius: 20) }
+		#endif
 			.listRowSeparator(.hidden)
 			.listRowBackground(Color.clear)
 			.listRowInsets(.zero)
 	}
 }
+
+#if os(iOS)
+	/// Shapes the keyboard focus halo to match the row's rounded background.
+	/// SwiftUI has no focus-shape API on iOS (`ContentShapeKinds.focusEffect` is
+	/// macOS/tvOS-only and `focusEffectDisabled()` has no effect on iOS), so the
+	/// halo is configured on the enclosing collection view cell via UIKit, per
+	/// WWDC21 "Focus on iPad keyboard navigation".
+	private struct FocusHaloShape: UIViewRepresentable {
+		var cornerRadius: CGFloat
+
+		func makeUIView(context _: Context) -> HaloShapingView {
+			HaloShapingView(cornerRadius: cornerRadius)
+		}
+
+		func updateUIView(_ uiView: HaloShapingView, context _: Context) {
+			uiView.cornerRadius = cornerRadius
+		}
+
+		final class HaloShapingView: UIView {
+			var cornerRadius: CGFloat = 0
+			private var appliedHaloRect: CGRect = .null
+
+			convenience init(cornerRadius: CGFloat) {
+				self.init(frame: .zero)
+				self.cornerRadius = cornerRadius
+				isUserInteractionEnabled = false
+			}
+
+			override func layoutSubviews() {
+				super.layoutSubviews()
+				guard bounds.width > 0, bounds.height > 0, let cell = enclosingCell else { return }
+				let haloRect = cell.convert(bounds, from: self)
+				// Reassigning the effect invalidates layout, so only assign when
+				// the geometry actually changes to avoid a layout/focus loop.
+				guard haloRect != appliedHaloRect else { return }
+				appliedHaloRect = haloRect
+				cell.focusEffect = UIFocusHaloEffect(
+					roundedRect: haloRect,
+					cornerRadius: cornerRadius,
+					curve: .continuous
+				)
+			}
+
+			private var enclosingCell: UICollectionViewCell? {
+				var view = superview
+				while let current = view, !(current is UICollectionViewCell) {
+					view = current.superview
+				}
+				return view as? UICollectionViewCell
+			}
+		}
+	}
+#endif
 
 #Preview {
 	GraphicalLocationListRow(location: TemporaryLocation.placeholderLondon)

--- a/Solstice/Settings/AboutSolsticeView.swift
+++ b/Solstice/Settings/AboutSolsticeView.swift
@@ -10,6 +10,10 @@ import SwiftUI
 struct AboutSolsticeView: View {
 	@Environment(\.colorScheme) private var colorScheme
 
+	#if os(macOS)
+		@State private var fullStoryPresented = false
+	#endif
+
 	var body: some View {
 		VStack(alignment: .leading, spacing: 8) {
 			HStack(alignment: .firstTextBaseline) {
@@ -39,12 +43,38 @@ struct AboutSolsticeView: View {
 
 				Divider()
 
-				NavigationLink(destination: FullStoryView()) {
-					Text("Read more")
-						.fontWeight(.medium)
-						.foregroundStyle(.tint)
-				}
-				.padding(.vertical, 4)
+				// The macOS settings window has no navigation stack to push into,
+				// so the full story is presented as a sheet there instead.
+				#if os(macOS)
+					Button {
+						fullStoryPresented = true
+					} label: {
+						readMoreLabel
+					}
+					.buttonStyle(.plain)
+					.padding(.vertical, 4)
+					.sheet(isPresented: $fullStoryPresented) {
+						FullStoryView()
+							.safeAreaInset(edge: .bottom) {
+								HStack {
+									Spacer()
+
+									Button("Done") {
+										fullStoryPresented = false
+									}
+									.keyboardShortcut(.defaultAction)
+								}
+								.padding()
+								.background(.bar)
+							}
+							.frame(minWidth: 480, minHeight: 440)
+					}
+				#else
+					NavigationLink(destination: FullStoryView()) {
+						readMoreLabel
+					}
+					.padding(.vertical, 4)
+				#endif
 			}
 			.font(.subheadline)
 			.foregroundStyle(.secondary)
@@ -53,6 +83,12 @@ struct AboutSolsticeView: View {
 		.blendMode(colorScheme == .light ? .plusDarker : .plusLighter)
 		.listRowBackground(Color.clear.background(Color.accentColor.quinary))
 		#endif
+	}
+
+	private var readMoreLabel: some View {
+		Text("Read more")
+			.fontWeight(.medium)
+			.foregroundStyle(.tint)
 	}
 }
 

--- a/Solstice/Settings/SettingsView.swift
+++ b/Solstice/Settings/SettingsView.swift
@@ -18,22 +18,84 @@ struct SettingsView: View {
 	@AppStorage(Preferences.timeTravelAppearance) private var timeTravelAppearance
 	@AppStorage(Preferences.chartType) private var chartType
 
+	#if os(macOS)
+		private enum SettingsPane: Hashable {
+			case general, appearance, notifications
+		}
+
+		@State private var selectedPane: SettingsPane = ScreenshotLaunch.macScreen == .settingsNotifications
+			? .notifications
+			: .general
+	#endif
+
 	var body: some View {
 		#if os(macOS)
-			if ScreenshotLaunch.macScreen == .settingsNotifications {
-				// macOS marketing shot: show the Notifications pane directly in the Settings window.
-				NavigationStack {
-					NotificationSettings()
-						.formStyle(.grouped)
-				}
-				.frame(minWidth: 420, minHeight: 520)
-				.accessibilityIdentifier(A11y.settingsWindow)
-			} else {
-				standardSettings
-			}
+			tabbedSettings
 		#else
 			standardSettings
 		#endif
+	}
+
+	#if os(macOS)
+		/// The Settings scene forces a System Settings-style window whose toolbar
+		/// renders navigation back buttons below the title, so macOS uses the
+		/// HIG-idiomatic pane switcher instead of push navigation.
+		private var tabbedSettings: some View {
+			TabView(selection: $selectedPane) {
+				Tab("About", systemImage: "info.circle", value: .general) {
+					Form {
+						Section {
+							AboutSolsticeView()
+						}
+
+						locationSection
+
+						SupporterSettings()
+					}
+					.formStyle(.grouped)
+				}
+
+				Tab("Appearance", systemImage: "paintpalette", value: .appearance) {
+					AppearanceSettingsView()
+				}
+
+				Tab("Notifications", systemImage: "bell.badge", value: .notifications) {
+					NotificationSettings()
+				}
+			}
+			// Lets the macOS screenshot capture locate the Settings window.
+			.accessibilityIdentifier(A11y.settingsWindow)
+		}
+	#endif
+
+	@ViewBuilder private var locationSection: some View {
+		if !currentLocation.isAuthorized {
+			Section {
+				Button("Enable location services", systemImage: "location") {
+					#if os(macOS)
+						// On macOS, open System Settings directly since requestWhenInUseAuthorization
+						// doesn't reliably trigger the authorization prompt
+						if let url = URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_LocationServices") {
+							NSWorkspace.shared.open(url)
+						}
+					#else
+						switch currentLocation.authorizationStatus {
+						case .notDetermined:
+							currentLocation.requestAccess()
+						case .restricted, .denied:
+							if let url = URL(string: UIApplication.openSettingsURLString) {
+								openURL(url)
+							}
+						default: return
+						}
+					#endif
+				}
+			} header: {
+				Text("Location")
+			} footer: {
+				Text("Enable location services to see the daylight duration in your current location")
+			}
+		}
 	}
 
 	@ViewBuilder private var standardSettings: some View {
@@ -43,33 +105,7 @@ struct SettingsView: View {
 					AboutSolsticeView()
 				}
 
-				if !currentLocation.isAuthorized {
-					Section {
-						Button("Enable location services", systemImage: "location") {
-							#if os(macOS)
-								// On macOS, open System Settings directly since requestWhenInUseAuthorization
-								// doesn't reliably trigger the authorization prompt
-								if let url = URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_LocationServices") {
-									NSWorkspace.shared.open(url)
-								}
-							#else
-								switch currentLocation.authorizationStatus {
-								case .notDetermined:
-									currentLocation.requestAccess()
-								case .restricted, .denied:
-									if let url = URL(string: UIApplication.openSettingsURLString) {
-										openURL(url)
-									}
-								default: return
-								}
-							#endif
-						}
-					} header: {
-						Text("Location")
-					} footer: {
-						Text("Enable location services to see the daylight duration in your current location")
-					}
-				}
+				locationSection
 
 				Section {
 					NavigationLink {
@@ -102,7 +138,6 @@ struct SettingsView: View {
 			.navigationTitle("Settings")
 			#endif
 			.formStyle(.grouped)
-			// Lets the macOS screenshot capture locate the Settings window.
 			.accessibilityIdentifier(A11y.settingsWindow)
 		}
 		#if !os(macOS)


### PR DESCRIPTION
## Summary

- **macOS: Settings window restructured as tabbed panes** (About / Appearance / Notifications). The macOS 26 `Settings` scene forces a System Settings-style window that renders NavigationStack back buttons *centered below the window title* — none of `.windowToolbarStyle(.unified)`, a custom `ToolbarItem(placement: .navigation)`, or `.toolbarTitleDisplayMode(.inline)` overrides it (each ruled out empirically via screenshots). Tabs are the HIG-idiomatic settings pattern and remove push navigation entirely. iOS/visionOS keep the existing navigation form.
- **macOS: "Read more" fixed** — it was a `NavigationLink`, inert without a stack; it now presents the full story in a sheet with a Done button.
- **iPadOS: sidebar focus halo** now matches the 20pt rounded corners of the graphical location rows via `UIFocusHaloEffect` on the hosting cell (no SwiftUI focus-shape API exists on iOS).
- **l10n:** new "About" and "Done" keys translated for all nine shipping locales (de, fr, es, it, nl, ja, zh-Hans, pl, ar).

## Verification

- macOS: exercised in the running app via scripted UI automation — all three panes render (Support pane loads live StoreKit prices), pane switching works, window title tracks the pane, and the Read more sheet opens and dismisses.
- Localization: string catalog reports 0 `new` strings per locale, so the CI localization gate passes.
- iOS and macOS builds pass.
- ⚠️ The iPadOS focus-halo commit is **build-verified but not behavior-verified**: keyboard focus doesn't engage in the Xcode 27 Device Hub simulator even on unmodified `main`, so it needs a hardware-keyboard test on a real iPad. It's isolated in its own commit (`eceb7cc`) and easy to drop if it misbehaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)