### PR TITLE
feat(screenshots): add iPadOS to the localized App Store screenshot pipeline

### DIFF
--- a/Scripts/capture-screenshots.sh
+++ b/Scripts/capture-screenshots.sh
@@ -13,6 +13,9 @@
 #   WIDGETS_ONLY=1 Scripts/capture-screenshots.sh # re-render only the Frame-4
 #                                                  # widgets (skips the iOS UI
 #                                                  # tests; leaves iOS shots intact)
+#   IPAD=1 Scripts/capture-screenshots.sh         # iPad marketing shots (ipad-*.png)
+#                                                  # on the 13" iPad simulator; leaves
+#                                                  # the iPhone shots + widgets intact
 #
 set -euo pipefail
 
@@ -29,11 +32,16 @@ RESULTS_DIR="$PWD/.screenshots/results"
 OUT_DIR="$PWD/Screenshots/output"
 
 # iPhone 17 Pro (6.3") — matches the device bezel in the Figma marketing
-# template. Swap to "iPhone 17 Pro Max" for the 6.9" App Store size, or add the
-# 13" iPad line if the app ships an iPad build.
+# template. Swap to "iPhone 17 Pro Max" for the 6.9" App Store size.
 DEVICE_NAME="iPhone 17 Pro"
 # DEVICE_NAME="iPhone 17 Pro Max"
-# DEVICE_NAME="iPad Pro 13-inch (M4)"
+
+# IPAD=1 captures the iPad marketing shots instead (portrait, to match the Figma
+# template's portrait device bezel; the 2732×2048 marketing canvas is composed in
+# Figma). Runs only the iPad UI test — iPhone shots and widget renders are untouched.
+if [ "${IPAD:-0}" = "1" ]; then
+	DEVICE_NAME="iPad Pro 13-inch (M5)"
+fi
 
 # All locales present in Screenshots.xctestplan. Override via CLI args.
 ALL_LOCALES=(en de fr es ja ar nl zh-Hans pl it)
@@ -46,8 +54,10 @@ echo "==> Locales: ${LOCALES[*]}"
 echo "==> Device:  $DEVICE_NAME"
 
 # Resolve (and boot) the target simulator so we can pin a clean status bar.
-UDID=$(xcrun simctl list devices available | awk -F '[()]' -v name="$DEVICE_NAME" '
-	$0 ~ name" \\(" { print $2; exit }')
+# Fixed-string match, because device names can themselves contain parentheses
+# (e.g. "iPad Pro 13-inch (M4)"); the UDID is the first 36-char hex token after.
+UDID=$(xcrun simctl list devices available | grep -F "$DEVICE_NAME (" | head -1 \
+	| grep -Eo '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}' | head -1)
 if [ -z "${UDID:-}" ]; then
 	echo "error: simulator '$DEVICE_NAME' not found (see: xcrun simctl list devices available)" >&2
 	exit 1
@@ -77,9 +87,13 @@ done
 
 # WIDGETS_ONLY re-renders just the Frame-4 marketing widgets (WidgetRenderTests),
 # skipping the slow iOS UI test — used when only widget content changed.
+# IPAD runs just the iPad marketing flow (the test also idiom-guards itself, but
+# narrowing here skips the pointless widget re-render on the iPad simulator).
 ONLY_TESTING=()
 if [ "${WIDGETS_ONLY:-0}" = "1" ]; then
 	ONLY_TESTING+=(-only-testing "SolsticeTests/WidgetRenderTests")
+elif [ "${IPAD:-0}" = "1" ]; then
+	ONLY_TESTING+=(-only-testing "SolsticeUITests/AppStoreScreenshots/testCaptureIPadAppStoreScreenshots")
 fi
 
 echo "==> Running screenshot test plan"
@@ -113,8 +127,13 @@ xcrun xcresulttool export attachments \
 echo "==> Normalizing into $OUT_DIR/<locale>/"
 for loc in "${LOCALES[@]}"; do
 	# Clear only what THIS run produces (iOS device shots + the Frame-4 widget
-	# renders); leave the macOS window shots (mac-01/02/03) from the other script.
-	# In WIDGETS_ONLY mode, leave the iOS shots too — only the widgets re-render.
+	# renders, or the iPad shots in IPAD mode); leave the macOS window shots
+	# (mac-01/02/03) from the other script. In WIDGETS_ONLY mode, leave the iOS
+	# shots too — only the widgets re-render.
+	if [ "${IPAD:-0}" = "1" ]; then
+		rm -f "${OUT_DIR:?}/$loc"/ipad-*.png
+		continue
+	fi
 	if [ "${WIDGETS_ONLY:-0}" != "1" ]; then
 		rm -f "${OUT_DIR:?}/$loc"/[0-9][0-9]-*.png
 	fi
@@ -126,9 +145,10 @@ python3 - "$RAW_DIR" "$OUT_DIR" <<'PY'
 import json, os, re, shutil, sys
 raw, out = sys.argv[1], sys.argv[2]
 manifest = json.load(open(os.path.join(raw, "manifest.json")))
-# Attachments are "<screen>_0_<uuid>.png": iOS shots ("02-detail-daily") and the
-# Frame-4 widget renders ("mac-04-widget-overview"). Locale = test-plan configuration.
-pat = re.compile(r"^((?:mac-)?\d\d-[a-z0-9-]+)_0_.*\.png$")
+# Attachments are "<screen>_0_<uuid>.png": iOS shots ("02-detail-daily"), the
+# Frame-4 widget renders ("mac-04-widget-overview") and the iPad shots
+# ("ipad-01-overview"). Locale = test-plan configuration.
+pat = re.compile(r"^((?:mac-|ipad-)?\d\d-[a-z0-9-]+)_0_.*\.png$")
 count = 0
 for group in manifest:
     for a in group.get("attachments", []):

--- a/Scripts/figma-compose.sh
+++ b/Scripts/figma-compose.sh
@@ -4,8 +4,9 @@
 # the Figma marketing file, deterministically, via the Figma MCP tools.
 #
 # Prereq: screenshots captured into Screenshots/output/<locale>/ (see
-# capture-screenshots.sh for iOS shots + widgets, capture-screenshots-macos.sh for
-# macOS window shots, capture-screenshots-watchos.sh for Apple Watch shots). The
+# capture-screenshots.sh for iOS shots + widgets — and, with IPAD=1, the iPad
+# shots — capture-screenshots-macos.sh for macOS window shots,
+# capture-screenshots-watchos.sh for Apple Watch shots). The
 # Figma templates are componentized (Stage A): each locale section is component
 # instances, so this only sets image fills — captions and all shared design come
 # from the master components. watchOS sections hold raw 422×514 shots (no
@@ -33,9 +34,9 @@
 # ── Phase 2: compose ──────────────────────────────────────────────────────────
 # Paste Scripts/figma/compose.js into the `use_figma` tool with the SOURCE_HASHES
 # object at the top filled from Phase 1, then run it. It fills every locale section's
-# instance slots (macOS windows + widgets, iOS device screenshots) idempotently and
-# returns { set, missing }. `missing` must be empty; a non-empty `missing` means a
-# hash key or a slot rule didn't match.
+# instance slots (macOS windows + widgets, iOS + iPadOS device screenshots)
+# idempotently and returns { set, missing }. `missing` must be empty; a non-empty
+# `missing` means a hash key or a slot rule didn't match.
 #
 # ── Verify ────────────────────────────────────────────────────────────────────
 # get_screenshot each locale section (e.g. macOS en 65:94, iOS ar 27:94) and confirm.

--- a/Scripts/figma/compose.js
+++ b/Scripts/figma/compose.js
@@ -22,6 +22,7 @@ const SOURCE_HASHES = {
 
 const SECTIONS = {
   ios:     { en:"10:94", de:"30:94", fr:"30:134", es:"30:174", ja:"18:94", ar:"27:94", nl:"30:214", "zh-Hans":"30:334", pl:"30:254", it:"30:294" },
+  ipados:  { en:"199:464", de:"199:509", fr:"199:554", es:"199:599", ja:"199:644", ar:"199:693", nl:"199:738", "zh-Hans":"199:783", pl:"199:828", it:"199:873" },
   macos:   { en:"65:94", de:"67:94", fr:"67:112", es:"67:130", ja:"67:148", ar:"67:166", nl:"67:184", "zh-Hans":"67:202", pl:"67:220", it:"67:238" },
   watchos: { en:"157:439", de:"157:446", fr:"157:453", es:"157:460", ja:"157:467", ar:"157:478", nl:"157:485", "zh-Hans":"157:492", pl:"157:499", it:"157:506" },
 };
@@ -30,6 +31,7 @@ const SECTIONS = {
 // so a partial capture (e.g. watch-only) doesn't report every other slot missing.
 const HAVE = {
   ios:     Object.keys(SOURCE_HASHES).some(k => /\/\d\d-/.test(k)),
+  ipados:  Object.keys(SOURCE_HASHES).some(k => k.includes("/ipad-")),
   macos:   Object.keys(SOURCE_HASHES).some(k => k.includes("/mac-")),
   watchos: Object.keys(SOURCE_HASHES).some(k => k.includes("/watch-")),
 };
@@ -54,6 +56,11 @@ const IOS_FRAMES = ["02-detail-daily", "03-detail-annual", "04-time-travel", "01
 // "watchOS Screenshot" instance PER FILE, named exactly after the source file, so
 // slots are matched by instance name (robust to reordering).
 const WATCH_FILES = ["watch-01-location-list", "watch-02-detail", "watch-03-time-travel"];
+
+// iPadOS: same instance-named-after-file convention as watchOS. Portrait
+// 2064×2752 captures fill the portrait device bezel inside each landscape
+// marketing frame (placeholder aspect 0.7501 vs capture 0.75 — FILL crops ~0.1%).
+const IPAD_FILES = ["ipad-01-overview", "ipad-02-notifications"];
 
 function hashFor(locale, file) {
   if (!file) return null;
@@ -99,6 +106,16 @@ if (HAVE.ios) for (const loc of Object.keys(SECTIONS.ios)) {
     if (setImage(slot, hash, "FIT")) report.set++;
     else report.missing.push(`ios/${loc}/frame${i + 1}/${file}`);
   });
+}
+
+if (HAVE.ipados) for (const loc of Object.keys(SECTIONS.ipados)) {
+  const kids = figma.getNodeById(SECTIONS.ipados[loc]).children;
+  for (const file of IPAD_FILES) {
+    const inst = kids.find(c => c.type === "INSTANCE" && c.name === file);
+    const slot = inst && inst.findOne(n => n.name === "Screenshot (REPLACE ME)");
+    if (setImage(slot, hashFor(loc, file), "FILL")) report.set++;
+    else report.missing.push(`ipados/${loc}/${file}`);
+  }
 }
 
 if (HAVE.watchos) for (const loc of Object.keys(SECTIONS.watchos)) {

--- a/Solstice/Helpers/ScreenshotSupport.swift
+++ b/Solstice/Helpers/ScreenshotSupport.swift
@@ -13,6 +13,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 /// Accessibility identifiers for elements captured in App Store screenshots.
 enum A11y {
@@ -41,6 +42,11 @@ enum ScreenshotLaunch {
 	/// Environment key: integer number of days to offset the Time Machine by.
 	static let timeOffsetDaysKey = "UITEST_TIME_OFFSET_DAYS"
 
+	/// Environment key: force "dark" or "light" appearance for the capture launch.
+	/// The simulator-level `XCUIDevice.shared.appearance` doesn't reliably reach a
+	/// running app, so the dark marketing shots force the scheme in-process instead.
+	static let appearanceKey = "UITEST_APPEARANCE"
+
 	/// Environment key: which macOS screen to open directly into for window capture.
 	static let macScreenKey = "UITEST_MAC_SCREEN"
 
@@ -66,6 +72,17 @@ enum ScreenshotLaunch {
 
 	static var macScreen: MacScreen? {
 		ProcessInfo.processInfo.environment[macScreenKey].flatMap(MacScreen.init(rawValue:))
+	}
+
+	/// Color scheme to force during capture, or nil for the system appearance
+	/// (always nil outside screenshot mode, so this never affects normal launches).
+	static var forcedColorScheme: ColorScheme? {
+		guard isCapturing else { return nil }
+		switch ProcessInfo.processInfo.environment[appearanceKey] {
+		case "dark": return .dark
+		case "light": return .light
+		default: return nil
+		}
 	}
 
 	/// Prepares deterministic defaults for screenshot capture. Call once at launch

--- a/Solstice/SolsticeApp.swift
+++ b/Solstice/SolsticeApp.swift
@@ -45,6 +45,9 @@ struct SolsticeApp: App {
 				.environment(nameResolver)
 				.environment(locationSearchService)
 				.environment(\.managedObjectContext, persistenceController.container.viewContext)
+				// Forced appearance for dark-mode marketing shots; nil (any normal
+				// launch) leaves the system appearance in charge.
+				.preferredColorScheme(ScreenshotLaunch.forcedColorScheme)
 			#if os(macOS)
 				// Deterministic, compact window size for marketing captures; nil leaves
 				// normal launches free to size/resize as usual.

--- a/SolsticeUITests/AppStoreScreenshots.swift
+++ b/SolsticeUITests/AppStoreScreenshots.swift
@@ -13,6 +13,7 @@
 //  backs out to the list and into settings.
 //
 
+import UIKit
 import XCTest
 
 final class AppStoreScreenshots: XCTestCase {
@@ -22,6 +23,7 @@ final class AppStoreScreenshots: XCTestCase {
 
 	@MainActor
 	func testCaptureAppStoreScreenshots() async throws {
+		try XCTSkipUnless(UIDevice.current.userInterfaceIdiom == .phone, "iPhone marketing flow")
 		let app = XCUIApplication()
 		app.launchArguments = [ScreenshotLaunch.flag]
 		app.launchEnvironment[ScreenshotLaunch.selectedLocationKey] = ScreenshotFixtures.selectedLocationUUID
@@ -70,6 +72,53 @@ final class AppStoreScreenshots: XCTestCase {
 		capture(app, named: "04-time-travel")
 	}
 
+	/// iPad marketing flow — matches the Figma "iPadOS Screenshot" template variants:
+	/// a light portrait overview (sidebar + detail) and a dark portrait shot of the
+	/// notification settings sheet. Portrait, because the template's device bezel is
+	/// portrait (the marketing canvas itself is landscape).
+	@MainActor
+	func testCaptureIPadAppStoreScreenshots() async throws {
+		try XCTSkipUnless(UIDevice.current.userInterfaceIdiom == .pad, "iPad marketing flow")
+
+		XCUIDevice.shared.orientation = .portrait
+
+		let app = XCUIApplication()
+		app.launchArguments = [ScreenshotLaunch.flag]
+		app.launchEnvironment[ScreenshotLaunch.selectedLocationKey] = ScreenshotFixtures.selectedLocationUUID
+		app.launch()
+
+		// ipad-01 — Overview: split view with the sidebar and the forced selection's
+		// detail both visible.
+		let detail = app.match(A11y.detailScreen)
+		XCTAssertTrue(detail.waitForExistence(timeout: 30), "Detail view never appeared")
+		var settingsButton = app.buttons[A11y.settingsButton]
+		if !settingsButton.isHittable {
+			// The sidebar collapsed (e.g. a stale column-visibility state); reveal it.
+			app.buttons["ToggleSidebar"].firstMatch.tap()
+			XCTAssertTrue(settingsButton.waitForExistence(timeout: 15), "Sidebar never appeared")
+		}
+		try await settle()
+		capture(app, named: "ipad-01-overview")
+
+		// ipad-02 — Notification settings sheet, dark appearance. Relaunch with the
+		// scheme forced in-process (UITEST_APPEARANCE): flipping the simulator's
+		// appearance mid-test via XCUIDevice doesn't reach the running app.
+		app.terminate()
+		app.launchEnvironment[ScreenshotLaunch.appearanceKey] = "dark"
+		app.launch()
+		XCTAssertTrue(app.match(A11y.detailScreen).waitForExistence(timeout: 30), "Detail view never reappeared")
+		settingsButton = app.buttons[A11y.settingsButton]
+		XCTAssertTrue(settingsButton.waitForExistence(timeout: 15), "Settings button never appeared")
+		settingsButton.tap()
+		try await settle()
+		let notificationsLink = app.match(A11y.notificationsLink)
+		app.scrollDown(untilHittable: notificationsLink)
+		XCTAssertTrue(notificationsLink.waitForExistence(timeout: 15), "Notifications link never appeared")
+		notificationsLink.tap()
+		try await settle()
+		capture(app, named: "ipad-02-notifications")
+	}
+
 	// MARK: - Helpers
 
 	@MainActor
@@ -107,13 +156,18 @@ private extension XCUIApplication {
 	/// chart) can report `isHittable == true` while only peeking from the bottom
 	/// edge, so `scrollDown(untilHittable:)` would stop without scrolling and
 	/// capture the same frame as the previous screen — this forces real movement.
+	/// Drags from the lower quarter of the screen rather than `swipeUp()`, whose
+	/// mid-screen start lands on the daily chart and gets consumed by the chart's
+	/// scrubbing gesture instead of scrolling.
 	func scrollUp(toReveal element: XCUIElement, maxSwipes: Int = 10) {
 		var swipes = 0
 		while swipes < maxSwipes {
 			if element.exists, element.isHittable, element.frame.minY < frame.midY {
 				return
 			}
-			swipeUp()
+			let start = coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.85))
+			let end = coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.35))
+			start.press(forDuration: 0.05, thenDragTo: end)
 			swipes += 1
 		}
 	}

--- a/SolsticeUITests/ScreenshotSupport.swift
+++ b/SolsticeUITests/ScreenshotSupport.swift
@@ -28,6 +28,7 @@ enum ScreenshotLaunch {
 	static let flag = "-UITestScreenshots"
 	static let selectedLocationKey = "UITEST_SELECTED_LOCATION"
 	static let timeOffsetDaysKey = "UITEST_TIME_OFFSET_DAYS"
+	static let appearanceKey = "UITEST_APPEARANCE"
 }
 
 /// The demo location the capture test opens. Its UUID is pre-seeded in


### PR DESCRIPTION
## Summary
Extends the localized App Store screenshot pipeline to iPadOS, matching the new "iPadOS Screenshot" Figma template components (landscape marketing canvas with a portrait 13" device bezel).

- **`IPAD=1 Scripts/capture-screenshots.sh [locales…]`** captures two portrait shots per locale on the iPad Pro 13-inch (M5) simulator — `ipad-01-overview` (light, split view) and `ipad-02-notifications` (dark, notification settings sheet) — leaving iPhone/macOS/widget shots untouched.
- New iPad UI-test flow in `AppStoreScreenshots.swift`; both flows idiom-guard themselves (`XCTSkipUnless`) so the shared `Screenshots` test plan runs on either device type.
- Dark mode is forced in-process via a new `UITEST_APPEARANCE` launch key + `.preferredColorScheme(ScreenshotLaunch.forcedColorScheme)` (capture-only; nil on normal launches). Flipping `XCUIDevice.shared.appearance` mid-test verifiably never reaches the running app.
- `compose.js` gains the 10 iPadOS locale sections + slot rules (instances named after source files, watchOS-style).
- Fixes the simulator UDID lookup for device names containing parentheses ("iPad Pro 13-inch (M5)").

## Bug fix (pre-existing, found during regression testing)
`app.swipeUp()` starts mid-screen, which on the detail view lands on the daily chart — its scrub gesture consumes the drag, so `03-detail-annual` silently captured identical bytes to `02-detail-daily` (deterministic). `scrollUp(toReveal:)` now drags from the lower quarter of the screen. Tripwire for future runs: `md5 -q 02*.png 03*.png` must differ.

## Test plan
- [x] `IPAD=1 Scripts/capture-screenshots.sh` — all 10 locales × 2 shots captured (2064×2752, light/dark verified, ja localization + ar RTL spot-checked)
- [x] All 20 shots composed into the Figma locale sections via `compose.js` (`{set: 20, missing: []}`), sections visually verified
- [x] `Scripts/capture-screenshots.sh en` — iPhone flow regression-passed; annual-chart shot now correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)