### PR TITLE
feat(sky): physics-based sky gradient

### DIFF
--- a/Solstice.xcodeproj/project.pbxproj
+++ b/Solstice.xcodeproj/project.pbxproj
@@ -73,10 +73,10 @@
 		712433942D77A4CE00709C20 /* EdgeInsets++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433922D77A4CE00709C20 /* EdgeInsets++.swift */; };
 		712433952D77A4CE00709C20 /* EdgeInsets++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433922D77A4CE00709C20 /* EdgeInsets++.swift */; };
 		712433962D77A4CE00709C20 /* EdgeInsets++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433922D77A4CE00709C20 /* EdgeInsets++.swift */; };
-		712433982D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433972D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift */; };
-		712433992D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433972D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift */; };
-		7124339A2D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433972D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift */; };
-		7124339B2D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433972D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift */; };
+		712433982D77A92000709C20 /* View+SkyChartGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433972D77A92000709C20 /* View+SkyChartGeometry.swift */; };
+		712433992D77A92000709C20 /* View+SkyChartGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433972D77A92000709C20 /* View+SkyChartGeometry.swift */; };
+		7124339A2D77A92000709C20 /* View+SkyChartGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433972D77A92000709C20 /* View+SkyChartGeometry.swift */; };
+		7124339B2D77A92000709C20 /* View+SkyChartGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433972D77A92000709C20 /* View+SkyChartGeometry.swift */; };
 		7124339E2D77B07500709C20 /* ShareSolarChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7124339C2D77B06900709C20 /* ShareSolarChartView.swift */; };
 		712433A52D78867300709C20 /* StackedLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433A42D78867300709C20 /* StackedLabelStyle.swift */; };
 		712433A62D78867300709C20 /* StackedLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712433A42D78867300709C20 /* StackedLabelStyle.swift */; };
@@ -422,7 +422,7 @@
 		7121DDFF29C22E7D0031EEE7 /* View+Debugging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Debugging.swift"; sourceTree = "<group>"; };
 		7123E75E30052CE20091C591 /* ScreenshotSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSupport.swift; sourceTree = "<group>"; };
 		712433922D77A4CE00709C20 /* EdgeInsets++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EdgeInsets++.swift"; sourceTree = "<group>"; };
-		712433972D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+DaylightGradientTimePreferenceKey.swift"; sourceTree = "<group>"; };
+		712433972D77A92000709C20 /* View+SkyChartGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+SkyChartGeometry.swift"; sourceTree = "<group>"; };
 		7124339C2D77B06900709C20 /* ShareSolarChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSolarChartView.swift; sourceTree = "<group>"; };
 		712433A42D78867300709C20 /* StackedLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackedLabelStyle.swift; sourceTree = "<group>"; };
 		712433A72D78870600709C20 /* StackedButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackedButtonStyle.swift; sourceTree = "<group>"; };
@@ -839,7 +839,7 @@
 				7195125729B48ECD009D282F /* TimeZone++.swift */,
 				71E3C4172EA12B030005C884 /* View+backportGlassEffect.swift */,
 				71F641C2299FD39E00FE5AB5 /* View+CapsuleAppearance.swift */,
-				712433972D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift */,
+				712433972D77A92000709C20 /* View+SkyChartGeometry.swift */,
 				7121DDFF29C22E7D0031EEE7 /* View+Debugging.swift */,
 				7195120029AFBBEC009D282F /* View+EllipticalEdgeMask.swift */,
 				711782E32E4E77AF0006CE5B /* View+glassButtonStyle.swift */,
@@ -1259,7 +1259,7 @@
 				71C105A62E7D311B00A76EBB /* TimeMachine++.swift in Sources */,
 				7188714529DC8C60001A4327 /* View+RectangularEdgeMask.swift in Sources */,
 				7150CC5A29AB7B3000E6B90C /* NotificationManager.swift in Sources */,
-				7124339A2D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift in Sources */,
+				7124339A2D77A92000709C20 /* View+SkyChartGeometry.swift in Sources */,
 				713F800129BE88E800BEA156 /* DaylightSummaryTitle.swift in Sources */,
 				715489B12F1FB8A500FD5CCE /* SolsticeWidgetView.swift in Sources */,
 				7106C87329A276B40007A7EC /* Widget.swift in Sources */,
@@ -1334,7 +1334,7 @@
 				719465422C2C1E09008408C0 /* View+RectangularEdgeMask.swift in Sources */,
 				715489B42F201D8400FD5CCE /* SolsticeWidgetLocationManager.swift in Sources */,
 				719465442C2C1E09008408C0 /* NotificationManager.swift in Sources */,
-				712433982D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift in Sources */,
+				712433982D77A92000709C20 /* View+SkyChartGeometry.swift in Sources */,
 				715489B22F1FB8A500FD5CCE /* SolsticeWidgetView.swift in Sources */,
 				7107208E3009257E006AA79C /* MarketingWidgetRenderer.swift in Sources */,
 				719465472C2C1E09008408C0 /* DaylightSummaryTitle.swift in Sources */,
@@ -1356,7 +1356,7 @@
 				71E3C4132EA12ABE0005C884 /* CircleWithSlice.swift in Sources */,
 				7198468E28E5895F00E866CE /* Persistence.swift in Sources */,
 				710D9B712AB4752D0093A9A6 /* ContentToggle.swift in Sources */,
-				7124339B2D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift in Sources */,
+				7124339B2D77A92000709C20 /* View+SkyChartGeometry.swift in Sources */,
 				7181776A2F2EA2EC007A2E9E /* LocationAppEntity.swift in Sources */,
 				7123E76130052CE20091C591 /* ScreenshotSupport.swift in Sources */,
 				71789AA52C32DCC7002B8A33 /* View+MaterialListRowBackground.swift in Sources */,
@@ -1495,7 +1495,7 @@
 				719F927D29ACD22100C06921 /* CurrentLocation.swift in Sources */,
 				718177642F2E9BCF007A2E9E /* SolsticeConfigurationIntent.swift in Sources */,
 				71FBEE6B2E4B345700EC1EF0 /* Bundle++.swift in Sources */,
-				712433992D77A92000709C20 /* View+DaylightGradientTimePreferenceKey.swift in Sources */,
+				712433992D77A92000709C20 /* View+SkyChartGeometry.swift in Sources */,
 				713F800029BE88E800BEA156 /* DaylightSummaryTitle.swift in Sources */,
 				711782E92E4E7CE20006CE5B /* AsyncButton.swift in Sources */,
 				719F927A29ACD21A00C06921 /* AppStorage++.swift in Sources */,

--- a/Solstice/Charts/CircularSolarChart.swift
+++ b/Solstice/Charts/CircularSolarChart.swift
@@ -20,7 +20,10 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 		@Environment(\.widgetFamily) private var widgetFamily
 	#endif
 
-	@State private var size = CGSize.zero
+	/// The dial's square edge length, measured synchronously in `body` — not lifecycle-captured
+	/// state, so size-derived elements (ticks, sun ring, glow anchor) are correct even in
+	/// single-pass render trees like the share card's `ImageRenderer`, where onAppear never runs.
+	private var size = CGSize.zero
 	var date: Date?
 
 	var location: Location
@@ -230,16 +233,6 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 	private var sundialBackground: some View {
 		background.mask {
 			Circle()
-				.overlay {
-					GeometryReader { g in
-						Color.clear.task(id: g.size) {
-							size = g.size
-						}
-						.onAppear {
-							size = g.size
-						}
-					}
-				}
 		}
 		.overlay {
 			sundialBorderOverlay
@@ -409,6 +402,21 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 	}
 
 	var body: some View {
+		GeometryReader { geo in
+			let chart = {
+				var chart = self
+				let side = min(geo.size.width, geo.size.height)
+				chart.size = CGSize(width: side, height: side)
+				return chart
+			}()
+			chart.dialContent
+				.frame(width: geo.size.width, height: geo.size.height)
+		}
+		.frame(maxWidth: .infinity)
+		.aspectRatio(1, contentMode: .fit)
+	}
+
+	private var dialContent: some View {
 		ZStack {
 			ZStack {
 				sundial
@@ -442,8 +450,6 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 		.font(.footnote)
 		.fontWeight(.medium)
 		.monospacedDigit()
-		.frame(maxWidth: .infinity)
-		.aspectRatio(1, contentMode: .fit)
 	}
 }
 

--- a/Solstice/Charts/CircularSolarChart.swift
+++ b/Solstice/Charts/CircularSolarChart.swift
@@ -30,6 +30,14 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 
 	var appearanceOverride: DaylightChart.Appearance?
 
+	/// Explicit because the private `size` property demotes the synthesized memberwise
+	/// initializer to private, making the view unconstructible from other files.
+	init(date: Date? = nil, location: Location, appearanceOverride: DaylightChart.Appearance? = nil) {
+		self.date = date
+		self.location = location
+		self.appearanceOverride = appearanceOverride
+	}
+
 	var appearance: DaylightChart.Appearance {
 		appearanceOverride ?? storedAppearance
 	}

--- a/Solstice/Charts/CircularSolarChart.swift
+++ b/Solstice/Charts/CircularSolarChart.swift
@@ -35,8 +35,17 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 		location.timeZone
 	}
 
+	/// Memoized: a single body evaluation reads this ~20 times (anchor, background, wedges, phase
+	/// slices, labels…), and each `NTSolar` construction solves the full set of solar events.
 	var solar: NTSolar? {
-		NTSolar(for: date ?? timeMachine.date, coordinate: location.coordinate, timeZone: location.timeZone)
+		let date = date ?? timeMachine.date
+		let key = SolarKey(date: date,
+		                   latitude: Int((location.coordinate.latitude * 1e4).rounded()),
+		                   longitude: Int((location.coordinate.longitude * 1e4).rounded()),
+		                   timeZone: location.timeZone.identifier)
+		return solarCache.value(for: key) {
+			NTSolar(for: date, coordinate: location.coordinate, timeZone: location.timeZone)
+		}
 	}
 
 	var majorSunSize: Double {
@@ -437,6 +446,15 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 		.aspectRatio(1, contentMode: .fit)
 	}
 }
+
+private struct SolarKey: Hashable {
+	let date: Date
+	let latitude: Int
+	let longitude: Int
+	let timeZone: String
+}
+
+private let solarCache = SkyRenderCache<SolarKey, NTSolar?>(capacity: 8)
 
 private struct ChartLabel: View {
 	#if WIDGET_EXTENSION

--- a/Solstice/Charts/CircularSolarChart.swift
+++ b/Solstice/Charts/CircularSolarChart.swift
@@ -114,8 +114,41 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 	@ViewBuilder
 	private var graphicalBackground: some View {
 		if let solar {
-			SkyGradient(ntSolar: solar, sunAnchor: sunAnchor)
+			// Each angle of the dial is coloured by the sky at that time of day, so day, each
+			// twilight band, and night appear as arcs in their true positions around the ring.
+			// The gradient starts at 90° because the dial places midnight at the bottom.
+			AngularGradient(stops: SkyModel.standard.dialStops(for: solar), center: .center, angle: .degrees(90))
+				.overlay {
+					// A soft glow at the current sun position. Its colour is the sky at the sun
+					// itself, so it brightens by day, warms at sunset, and fades out at night.
+					if let sunAnchor {
+						let altitude = solar.altitude(at: solar.date)
+						RadialGradient(
+							colors: [
+								SkyModel.standard.color(sunAltitudeDeg: altitude,
+								                        viewElevationDeg: max(altitude, SkyModel.standard.groundSourceElevationDeg),
+								                        scatterCosTheta: 1),
+								.clear,
+							],
+							center: sunAnchor,
+							startRadius: 0,
+							endRadius: max(44, max(size.width, size.height) * 0.4)
+						)
+						.blendMode(.plusLighter)
+					}
+				}
 		}
+	}
+
+	/// Whether the dial sits on the graphical sky background — in which case the angular sky
+	/// already renders the day, twilight, and night arcs, and the flat phase darkening would
+	/// only muddy them.
+	private var showsGraphicalSky: Bool {
+		#if WIDGET_EXTENSION
+			return widgetRenderingMode == .fullColor && appearance == .graphical
+		#else
+			return appearance == .graphical
+		#endif
 	}
 
 	@ViewBuilder
@@ -222,9 +255,11 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 		   let sunrise,
 		   let sunset
 		{
-			CircleWithSlice(startAngle: angle(for: sunrise).degrees, endAngle: angle(for: sunset).degrees)
-				.fill(.black.opacity(0.06))
-				.blendMode(.plusDarker)
+			if !showsGraphicalSky {
+				CircleWithSlice(startAngle: angle(for: sunrise).degrees, endAngle: angle(for: sunset).degrees)
+					.fill(.black.opacity(0.06))
+					.blendMode(.plusDarker)
+			}
 
 			phaseLines(sunrise: sunrise, sunset: sunset)
 		}

--- a/Solstice/Charts/CircularSolarChart.swift
+++ b/Solstice/Charts/CircularSolarChart.swift
@@ -102,12 +102,28 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 		Helpers.angle(for: date, timeZone: timeZone)
 	}
 
+	/// The sun's position on the dial, as a `UnitPoint` in the gradient's bounds, so the sky glow
+	/// tracks the sun dot around the ring. Midnight sits at the bottom, noon at the top.
+	private var sunAnchor: UnitPoint? {
+		guard let solar else { return nil }
+		let theta = angle(for: solar.date).radians
+		let radius = 0.4
+		return UnitPoint(x: 0.5 + radius * cos(theta), y: 0.5 + radius * sin(theta))
+	}
+
+	@ViewBuilder
+	private var graphicalBackground: some View {
+		if let solar {
+			SkyGradient(ntSolar: solar, sunAnchor: sunAnchor)
+		}
+	}
+
 	@ViewBuilder
 	var background: some View {
 		#if WIDGET_EXTENSION
 			if widgetRenderingMode == .fullColor {
 				if appearance == .graphical {
-					solar?.view
+					graphicalBackground
 				} else {
 					Rectangle().fill(.regularMaterial)
 				}
@@ -116,7 +132,7 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 			}
 		#else
 			if appearance == .graphical {
-				solar?.view
+				graphicalBackground
 			} else {
 				Rectangle().fill(.regularMaterial)
 			}

--- a/Solstice/Charts/CircularSolarChart.swift
+++ b/Solstice/Charts/CircularSolarChart.swift
@@ -118,7 +118,7 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 				// Static ring: each angle coloured by the sky at that time of day, so night and the
 				// twilight bands appear as arcs in their true positions around the dial. The
 				// gradient starts at 90° because the dial places midnight at the bottom.
-				AngularGradient(stops: SkyModel.standard.dialStops(for: solar), center: .center, angle: .degrees(90))
+				AngularGradient(stops: SkyModel.standard.cachedDialStops(for: solar), center: .center, angle: .degrees(90))
 
 				// Dynamic day wedge: the sunrise→sunset slice always shows the sky as it looks
 				// right now, with the glow anchored to the sun dot.

--- a/Solstice/Charts/CircularSolarChart.swift
+++ b/Solstice/Charts/CircularSolarChart.swift
@@ -103,11 +103,13 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 	}
 
 	/// The sun's position on the dial, as a `UnitPoint` in the gradient's bounds, so the sky glow
-	/// tracks the sun dot around the ring. Midnight sits at the bottom, noon at the top.
+	/// tracks the sun dot around the ring. Midnight sits at the bottom, noon at the top. The
+	/// radius mirrors `sundialCenter`'s layout — a frame ⅔ of the dial with the dot's centre
+	/// inset half a sun from its edge — so the glow lands exactly on the dot.
 	private var sunAnchor: UnitPoint? {
-		guard let solar else { return nil }
+		guard let solar, size.width > 0 else { return nil }
 		let theta = angle(for: solar.date).radians
-		let radius = 0.4
+		let radius = (size.width / 3 - majorSunSize / 2) / size.width
 		return UnitPoint(x: 0.5 + radius * cos(theta), y: 0.5 + radius * sin(theta))
 	}
 

--- a/Solstice/Charts/CircularSolarChart.swift
+++ b/Solstice/Charts/CircularSolarChart.swift
@@ -114,29 +114,19 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 	@ViewBuilder
 	private var graphicalBackground: some View {
 		if let solar {
-			// Each angle of the dial is coloured by the sky at that time of day, so day, each
-			// twilight band, and night appear as arcs in their true positions around the ring.
-			// The gradient starts at 90° because the dial places midnight at the bottom.
-			AngularGradient(stops: SkyModel.standard.dialStops(for: solar), center: .center, angle: .degrees(90))
-				.overlay {
-					// A soft glow at the current sun position. Its colour is the sky at the sun
-					// itself, so it brightens by day, warms at sunset, and fades out at night.
-					if let sunAnchor {
-						let altitude = solar.altitude(at: solar.date)
-						RadialGradient(
-							colors: [
-								SkyModel.standard.color(sunAltitudeDeg: altitude,
-								                        viewElevationDeg: max(altitude, SkyModel.standard.groundSourceElevationDeg),
-								                        scatterCosTheta: 1),
-								.clear,
-							],
-							center: sunAnchor,
-							startRadius: 0,
-							endRadius: max(44, max(size.width, size.height) * 0.4)
-						)
-						.blendMode(.plusLighter)
+			ZStack {
+				// Static ring: each angle coloured by the sky at that time of day, so night and the
+				// twilight bands appear as arcs in their true positions around the dial. The
+				// gradient starts at 90° because the dial places midnight at the bottom.
+				AngularGradient(stops: SkyModel.standard.dialStops(for: solar), center: .center, angle: .degrees(90))
+
+				// Dynamic day wedge: the sunrise→sunset slice always shows the sky as it looks
+				// right now, with the glow anchored to the sun dot.
+				SkyGradient(ntSolar: solar, sunAnchor: sunAnchor)
+					.reverseMask {
+						safeSunriseSunsetShape
 					}
-				}
+			}
 		}
 	}
 

--- a/Solstice/Charts/CircularSolarChart.swift
+++ b/Solstice/Charts/CircularSolarChart.swift
@@ -172,18 +172,36 @@ struct CircularSolarChart<Location: AnyLocation>: View {
 	}
 
 	var belowHorizonSun: some View {
-		background.mask {
-			Circle()
+		Circle()
+			.fill(belowHorizonSunFill)
+			.overlay {
+				Circle()
+					.fill(.clear)
+					.strokeBorder(foregroundStyle, lineWidth: 2)
+			}
+			.frame(width: majorSunSize)
+			.frame(maxWidth: .infinity, alignment: .trailing)
+			.rotationEffect(angle(for: solar?.date ?? .now))
+			.frame(maxWidth: .infinity, maxHeight: .infinity)
+	}
+
+	/// The "empty" below-horizon sun should read as a hole showing the background through it. The
+	/// background can't literally be sampled at the marker's position, but on the graphical sky the
+	/// static ring's colour at the sun's angle is, by construction, the sky at the current moment —
+	/// so evaluating the model directly gives a matching fill. Other modes use their flat background.
+	private var belowHorizonSunFill: AnyShapeStyle {
+		if showsGraphicalSky, let solar {
+			let model = SkyModel.standard
+			return AnyShapeStyle(model.color(sunAltitudeDeg: solar.altitude(at: solar.date),
+			                                 viewElevationDeg: model.dialViewElevationDeg,
+			                                 scatterCosTheta: model.dialScatterCosTheta))
 		}
-		.overlay {
-			Circle()
-				.fill(.clear)
-				.strokeBorder(foregroundStyle, lineWidth: 2)
-		}
-		.frame(width: majorSunSize)
-		.frame(maxWidth: .infinity, alignment: .trailing)
-		.rotationEffect(angle(for: solar?.date ?? .now))
-		.frame(maxWidth: .infinity, maxHeight: .infinity)
+		#if WIDGET_EXTENSION
+			if widgetRenderingMode != .fullColor {
+				return AnyShapeStyle(.primary.quinary)
+			}
+		#endif
+		return AnyShapeStyle(.regularMaterial)
 	}
 
 	var safeSunriseSunsetShape: some Shape {
@@ -472,5 +490,12 @@ private enum Helpers {
 
 #Preview {
 	CircularSolarChart(location: TemporaryLocation.placeholderLondon)
+		.padding()
+}
+
+#Preview("Half a day away") {
+	// Whatever the current time, this shows the opposite side of the day — handy for checking the
+	// below-horizon sun marker and the twilight arcs at night.
+	CircularSolarChart(date: .now.addingTimeInterval(.twentyFourHours / 2), location: TemporaryLocation.placeholderLondon)
 		.padding()
 }

--- a/Solstice/Charts/DaylightChart.swift
+++ b/Solstice/Charts/DaylightChart.swift
@@ -31,6 +31,10 @@ struct DaylightChart: View {
 	var scrubbable = false
 	var markSize: CGFloat = 6
 	var yScale: ClosedRange<Double>? = nil
+	/// Whether to publish `SkyChartGeometryPreferenceKey` for a `SkyGradient` background. Only the
+	/// container that defines the `skyGradient` coordinate space should opt in — resolving the
+	/// named space in a hierarchy that lacks it logs a runtime warning on every evaluation.
+	var tracksSkyGeometry = false
 
 	/// The date to highlight — uses scrubbable position when dragging, otherwise the solar date.
 	var plotDate: Date {
@@ -206,8 +210,10 @@ struct DaylightChart: View {
 		scrubHitArea(geo: geo, proxy: proxy)
 
 		// Report the sun marker and horizon line so a SkyGradient background can align with them.
-		Color.clear
-			.preference(key: SkyChartGeometryPreferenceKey.self, value: skyGeometry(proxy: proxy, geo: geo))
+		if tracksSkyGeometry {
+			Color.clear
+				.preference(key: SkyChartGeometryPreferenceKey.self, value: skyGeometry(proxy: proxy, geo: geo))
+		}
 	}
 
 	/// The sun marker's position and the horizon line's y, expressed in the shared `skyGradient`

--- a/Solstice/Charts/DaylightChart.swift
+++ b/Solstice/Charts/DaylightChart.swift
@@ -202,6 +202,21 @@ struct DaylightChart: View {
 		}
 
 		scrubHitArea(geo: geo, proxy: proxy)
+
+		// Report the sun marker's position so a SkyGradient background can anchor its glow to it.
+		Color.clear
+			.preference(key: SkySunAnchorPreferenceKey.self, value: sunAnchorPoint(proxy: proxy, geo: geo))
+	}
+
+	/// The sun marker's position expressed in the shared `skyGradient` coordinate space.
+	private func sunAnchorPoint(proxy: ChartProxy, geo: GeometryProxy) -> CGPoint? {
+		guard let sunX = proxy.position(forX: sunDisplayOffset),
+		      let sunY = proxy.position(forY: yValue(for: sunDisplayOffset))
+		else {
+			return nil
+		}
+		let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
+		return CGPoint(x: frame.minX + sunX, y: frame.minY + sunY)
 	}
 
 	private func horizonLine(width: CGFloat, yOffset: CGFloat) -> some View {

--- a/Solstice/Charts/DaylightChart.swift
+++ b/Solstice/Charts/DaylightChart.swift
@@ -17,9 +17,15 @@ struct DaylightChart: View {
 
 	@State private var selectedEvent: NTSolar.Event?
 	@State private var currentX: TimeInterval?
-	/// Tracks the sun marker's current position. Updated instantly during time travel
-	/// and animated along the solar path on reset.
-	@State private var sunDisplayOffset: TimeInterval = 0
+	/// Overrides the sun marker's position while it animates (live scrubs, glide-home, time
+	/// travel resets). `nil` means "at the plotted time" — which also keeps static render trees
+	/// correct (the share card's ImageRenderer never runs onAppear, so no lifecycle seeding).
+	@State private var sunOffsetOverride: TimeInterval?
+
+	/// The sun marker's current position along the day.
+	private var sunDisplayOffset: TimeInterval {
+		sunOffsetOverride ?? plotOffset
+	}
 
 	var solar: NTSolar
 	var timeZone: TimeZone
@@ -150,32 +156,29 @@ struct DaylightChart: View {
 		// system; the summary title and surrounding UI still follow the locale.
 		.environment(\.layoutDirection, .leftToRight)
 		.animation(timeMachine.isActive ? nil : .smooth(duration: 0.5), value: solar.date)
-		.onAppear {
-			sunDisplayOffset = plotOffset
-		}
 		.onChange(of: currentX) { _, newValue in
 			if let newValue {
 				// Live scrub: the sun sticks to the finger.
-				sunDisplayOffset = newValue
+				sunOffsetOverride = newValue
 			} else {
 				// Scrub released: glide home along the solar curve (see AlongSolarPath).
 				withAnimation(.smooth(duration: 0.6)) {
-					sunDisplayOffset = plotOffset
+					sunOffsetOverride = plotOffset
 				}
 			}
 		}
 		.onChange(of: solar.date) { oldDate, _ in
 			if timeMachine.isActive {
-				sunDisplayOffset = plotOffset
+				sunOffsetOverride = plotOffset
 			} else {
 				// On reset: animate the sun along the new day's solar path from
 				// the old time position to the current time position.
 				var cal = Calendar.current
 				cal.timeZone = timeZone
 				let oldMidnight = cal.startOfDay(for: oldDate)
-				sunDisplayOffset = oldDate.timeIntervalSince(oldMidnight)
+				sunOffsetOverride = oldDate.timeIntervalSince(oldMidnight)
 				withAnimation(.smooth(duration: 0.5)) {
-					sunDisplayOffset = plotOffset
+					sunOffsetOverride = plotOffset
 				}
 			}
 		}

--- a/Solstice/Charts/DaylightChart.swift
+++ b/Solstice/Charts/DaylightChart.swift
@@ -98,7 +98,6 @@ struct DaylightChart: View {
 				.environment(\.colorScheme, .dark)
 		}
 		.environment(\.timeZone, timeZone)
-		.preference(key: DaylightGradientTimePreferenceKey.self, value: plotDate)
 	}
 
 	private var chartContent: some View {
@@ -220,7 +219,7 @@ struct DaylightChart: View {
 	/// coordinate space.
 	private func skyGeometry(proxy: ChartProxy, geo: GeometryProxy) -> SkyChartGeometry {
 		let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
-		var geometry = SkyChartGeometry()
+		var geometry = SkyChartGeometry(date: plotDate)
 
 		if let sunX = proxy.position(forX: sunDisplayOffset),
 		   let sunY = proxy.position(forY: yValue(for: sunDisplayOffset))

--- a/Solstice/Charts/DaylightChart.swift
+++ b/Solstice/Charts/DaylightChart.swift
@@ -203,20 +203,28 @@ struct DaylightChart: View {
 
 		scrubHitArea(geo: geo, proxy: proxy)
 
-		// Report the sun marker's position so a SkyGradient background can anchor its glow to it.
+		// Report the sun marker and horizon line so a SkyGradient background can align with them.
 		Color.clear
-			.preference(key: SkySunAnchorPreferenceKey.self, value: sunAnchorPoint(proxy: proxy, geo: geo))
+			.preference(key: SkyChartGeometryPreferenceKey.self, value: skyGeometry(proxy: proxy, geo: geo))
 	}
 
-	/// The sun marker's position expressed in the shared `skyGradient` coordinate space.
-	private func sunAnchorPoint(proxy: ChartProxy, geo: GeometryProxy) -> CGPoint? {
-		guard let sunX = proxy.position(forX: sunDisplayOffset),
-		      let sunY = proxy.position(forY: yValue(for: sunDisplayOffset))
-		else {
-			return nil
-		}
+	/// The sun marker's position and the horizon line's y, expressed in the shared `skyGradient`
+	/// coordinate space.
+	private func skyGeometry(proxy: ChartProxy, geo: GeometryProxy) -> SkyChartGeometry {
 		let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
-		return CGPoint(x: frame.minX + sunX, y: frame.minY + sunY)
+		var geometry = SkyChartGeometry()
+
+		if let sunX = proxy.position(forX: sunDisplayOffset),
+		   let sunY = proxy.position(forY: yValue(for: sunDisplayOffset))
+		{
+			geometry.sunPoint = CGPoint(x: frame.minX + sunX, y: frame.minY + sunY)
+		}
+
+		if let horizonY = proxy.position(forY: 0.0) {
+			geometry.horizonY = frame.minY + horizonY
+		}
+
+		return geometry
 	}
 
 	private func horizonLine(width: CGFloat, yOffset: CGFloat) -> some View {
@@ -263,14 +271,19 @@ struct DaylightChart: View {
 				.blendMode(.normal)
 		}
 		.background {
-			// Deepen the sky toward night below the horizon: a gentle dip right under the horizon
-			// line, ramping to black at the bottom, so twilight is barely visible below the horizon.
-			LinearGradient(
-				colors: isLuminanceReduced ? [.white, .white] : [Color(white: 0.55), .black],
-				startPoint: .top,
-				endPoint: .bottom
-			)
-			.blendMode(.multiply)
+			// In simple appearance the chart sits on a plain background, so a subtle veil marks the
+			// below-horizon region. In graphical appearance the SkyGradient mesh renders the ground
+			// itself (see SkyModel.mesh(horizonFraction:)) — anything painted here would darken the
+			// chart's own marks and stop short of the background's edges.
+			if appearance == .simple {
+				Rectangle()
+					.fill(.clear)
+					.background(.background.opacity(isLuminanceReduced ? 0 : 0.3))
+					.mask {
+						LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
+					}
+					.blendMode(.overlay)
+			}
 		}
 		.mask(alignment: .bottom) {
 			Rectangle()

--- a/Solstice/Charts/DaylightChart.swift
+++ b/Solstice/Charts/DaylightChart.swift
@@ -263,13 +263,14 @@ struct DaylightChart: View {
 				.blendMode(.normal)
 		}
 		.background {
-			Rectangle()
-				.fill(.clear)
-				.background(.background.opacity(isLuminanceReduced ? 0 : 0.3))
-				.mask {
-					LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
-				}
-				.blendMode(.overlay)
+			// Deepen the sky toward night below the horizon: a gentle dip right under the horizon
+			// line, ramping to black at the bottom, so twilight is barely visible below the horizon.
+			LinearGradient(
+				colors: isLuminanceReduced ? [.white, .white] : [Color(white: 0.55), .black],
+				startPoint: .top,
+				endPoint: .bottom
+			)
+			.blendMode(.multiply)
 		}
 		.mask(alignment: .bottom) {
 			Rectangle()

--- a/Solstice/Charts/DaylightChart.swift
+++ b/Solstice/Charts/DaylightChart.swift
@@ -153,8 +153,16 @@ struct DaylightChart: View {
 		.onAppear {
 			sunDisplayOffset = plotOffset
 		}
-		.onChange(of: currentX) { _, _ in
-			sunDisplayOffset = currentX ?? plotOffset
+		.onChange(of: currentX) { _, newValue in
+			if let newValue {
+				// Live scrub: the sun sticks to the finger.
+				sunDisplayOffset = newValue
+			} else {
+				// Scrub released: glide home along the solar curve (see AlongSolarPath).
+				withAnimation(.smooth(duration: 0.6)) {
+					sunDisplayOffset = plotOffset
+				}
+			}
 		}
 		.onChange(of: solar.date) { oldDate, _ in
 			if timeMachine.isActive {
@@ -209,29 +217,54 @@ struct DaylightChart: View {
 		scrubHitArea(geo: geo, proxy: proxy)
 
 		// Report the sun marker and horizon line so a SkyGradient background can align with them.
+		// Wrapped in AlongSolarPath so the glow (and its colours) glide with the marker whenever
+		// the offset animates, instead of jumping to the destination.
 		if tracksSkyGeometry {
-			Color.clear
-				.preference(key: SkyChartGeometryPreferenceKey.self, value: skyGeometry(proxy: proxy, geo: geo))
+			AlongSolarPath(offset: sunDisplayOffset) { offset in
+				Color.clear
+					.preference(key: SkyChartGeometryPreferenceKey.self,
+					            value: skyGeometry(offset: offset, proxy: proxy, geo: geo))
+			}
 		}
 	}
 
-	/// The sun marker's position and the horizon line's y, expressed in the shared `skyGradient`
-	/// coordinate space.
-	private func skyGeometry(proxy: ChartProxy, geo: GeometryProxy) -> SkyChartGeometry {
-		let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
-		var geometry = SkyChartGeometry(date: plotDate)
+	/// The sun's position at `offset` in the chart's own coordinates.
+	private func sunPosition(for offset: TimeInterval, proxy: ChartProxy) -> CGPoint {
+		CGPoint(x: proxy.position(forX: offset) ?? 0,
+		        y: proxy.position(forY: yValue(for: offset)) ?? 0)
+	}
 
-		if let sunX = proxy.position(forX: sunDisplayOffset),
-		   let sunY = proxy.position(forY: yValue(for: sunDisplayOffset))
-		{
-			geometry.sunPoint = CGPoint(x: frame.minX + sunX, y: frame.minY + sunY)
-		}
+	/// The plotted moment, sun position, and horizon line for `offset`, expressed in the shared
+	/// `skyGradient` coordinate space.
+	private func skyGeometry(offset: TimeInterval, proxy: ChartProxy, geo: GeometryProxy) -> SkyChartGeometry {
+		let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
+		var geometry = SkyChartGeometry(date: midnight.addingTimeInterval(offset))
+
+		let position = sunPosition(for: offset, proxy: proxy)
+		geometry.sunPoint = CGPoint(x: frame.minX + position.x, y: frame.minY + position.y)
 
 		if let horizonY = proxy.position(forY: 0.0) {
 			geometry.horizonY = frame.minY + horizonY
 		}
 
 		return geometry
+	}
+
+	/// Renders content derived from the sun's time offset, animating *along the solar curve*: the
+	/// offset itself is the animatable data, so every animation frame re-derives geometry from the
+	/// curve instead of interpolating positions in a straight line across it.
+	private struct AlongSolarPath<Content: View>: View, Animatable {
+		var offset: TimeInterval
+		@ViewBuilder var content: (TimeInterval) -> Content
+
+		var animatableData: TimeInterval {
+			get { offset }
+			set { offset = newValue }
+		}
+
+		var body: some View {
+			content(offset)
+		}
 	}
 
 	private func horizonLine(width: CGFloat, yOffset: CGFloat) -> some View {
@@ -241,30 +274,33 @@ struct DaylightChart: View {
 			.offset(y: yOffset)
 	}
 
-	@ViewBuilder
 	private func scrubIndicator(proxy: ChartProxy, geoHeight: CGFloat) -> some View {
-		if let currentX {
-			let xPos: CGFloat = proxy.position(forX: currentX) ?? 0
-			RoundedRectangle(cornerRadius: 8)
-				.fill(markForegroundColor)
-				.frame(width: 2, height: geoHeight)
-				.position(x: xPos, y: geoHeight / 2)
-				.overlay {
-					Rectangle()
-						.stroke(style: StrokeStyle(lineWidth: 1))
-						.fill(.background)
-						.frame(width: 2, height: geoHeight)
-						.position(x: xPos, y: geoHeight / 2)
-				}
+		Group {
+			if let currentX {
+				let xPos: CGFloat = proxy.position(forX: currentX) ?? 0
+				RoundedRectangle(cornerRadius: 8)
+					.fill(markForegroundColor)
+					.frame(width: 2, height: geoHeight)
+					.position(x: xPos, y: geoHeight / 2)
+					.overlay {
+						Rectangle()
+							.stroke(style: StrokeStyle(lineWidth: 1))
+							.fill(.background)
+							.frame(width: 2, height: geoHeight)
+							.position(x: xPos, y: geoHeight / 2)
+					}
+					.transition(.opacity)
+			}
 		}
+		// Keyed to presence, not value: appearing and disappearing fade, while the per-tick
+		// position updates during the scrub stay glued to the finger.
+		.animation(.easeInOut(duration: 0.2), value: currentX == nil)
 	}
 
 	private func sunBelowHorizon(proxy: ChartProxy, geo: GeometryProxy, horizonY: CGFloat) -> some View {
-		let sunX: CGFloat = proxy.position(forX: sunDisplayOffset) ?? 0
-		let sunY: CGFloat = proxy.position(forY: yValue(for: sunDisplayOffset)) ?? 0
 		let belowHorizonHeight: CGFloat = geo.size.height - horizonY
 
-		return ZStack {
+		return AlongSolarPath(offset: sunDisplayOffset) { offset in
 			Circle()
 				.fill(markBackgroundColor)
 				.overlay {
@@ -273,7 +309,7 @@ struct DaylightChart: View {
 						.fill(markForegroundColor)
 				}
 				.frame(width: markSize * 2.5, height: markSize * 2.5)
-				.position(x: sunX, y: sunY)
+				.position(sunPosition(for: offset, proxy: proxy))
 				.shadow(color: .secondary.opacity(0.5), radius: 2)
 				.blendMode(.normal)
 		}
@@ -299,14 +335,11 @@ struct DaylightChart: View {
 	}
 
 	private func sunAboveHorizon(proxy: ChartProxy, horizonY: CGFloat) -> some View {
-		let sunX: CGFloat = proxy.position(forX: sunDisplayOffset) ?? 0
-		let sunY: CGFloat = proxy.position(forY: yValue(for: sunDisplayOffset)) ?? 0
-
-		return ZStack {
+		AlongSolarPath(offset: sunDisplayOffset) { offset in
 			Circle()
 				.fill(markForegroundColor)
 				.frame(width: markSize * 2.5, height: markSize * 2.5)
-				.position(x: sunX, y: sunY)
+				.position(sunPosition(for: offset, proxy: proxy))
 				.shadow(color: .secondary.opacity(0.5), radius: 3)
 		}
 		.mask(alignment: .top) {

--- a/Solstice/Charts/DaylightChart.swift
+++ b/Solstice/Charts/DaylightChart.swift
@@ -99,10 +99,12 @@ struct DaylightChart: View {
 
 	private var chartContent: some View {
 		Chart {
-			ForEach(hours, id: \.self) { offset in
+			let hours = hours
+			let altitudes = sampledAltitudes
+			ForEach(hours.indices, id: \.self) { index in
 				LineMark(
-					x: .value("Time", offset),
-					y: .value("Altitude", yValue(for: offset))
+					x: .value("Time", hours[index]),
+					y: .value("Altitude", altitudes[index])
 				)
 				.interpolationMethod(.catmullRom)
 				.foregroundStyle(solarPathGradient)
@@ -238,7 +240,7 @@ struct DaylightChart: View {
 	private func scrubIndicator(proxy: ChartProxy, geoHeight: CGFloat) -> some View {
 		if let currentX {
 			let xPos: CGFloat = proxy.position(forX: currentX) ?? 0
-			Rectangle()
+			RoundedRectangle(cornerRadius: 8)
 				.fill(markForegroundColor)
 				.frame(width: 2, height: geoHeight)
 				.position(x: xPos, y: geoHeight / 2)
@@ -380,7 +382,7 @@ extension DaylightChart {
 	/// Callers may override via the `yScale` property.
 	private var effectiveYScale: ClosedRange<Double> {
 		if let yScale { return yScale }
-		let altitudes = hours.map { yValue(for: $0) }
+		let altitudes = sampledAltitudes
 		guard let minAlt = altitudes.min(), let maxAlt = altitudes.max() else {
 			return -90.0 ... 90.0
 		}
@@ -393,6 +395,17 @@ extension DaylightChart {
 	/// 0° is the geometric horizon; positive = above, negative = below.
 	func yValue(for offset: TimeInterval) -> Double {
 		solar.altitude(at: midnight.addingTimeInterval(offset))
+	}
+
+	/// Altitude for every sampled hour. Memoized because the body re-evaluates every frame during
+	/// scrubbing and time travel while the sampled day and place rarely change.
+	private var sampledAltitudes: [Double] {
+		let key = AltitudeSamplesKey(midnight: midnight,
+		                             latitude: Int((solar.coordinate.latitude * 1e4).rounded()),
+		                             longitude: Int((solar.coordinate.longitude * 1e4).rounded()))
+		return altitudeSamplesCache.value(for: key) {
+			hours.map { yValue(for: $0) }
+		}
 	}
 
 	/// Seconds from midnight of `solar.date` to the given event date.
@@ -420,6 +433,14 @@ extension DaylightChart {
 		}
 	}
 }
+
+private struct AltitudeSamplesKey: Hashable {
+	let midnight: Date
+	let latitude: Int
+	let longitude: Int
+}
+
+private let altitudeSamplesCache = SkyRenderCache<AltitudeSamplesKey, [Double]>(capacity: 16)
 
 extension DaylightChart {
 	enum Appearance: String, Codable, CaseIterable {

--- a/Solstice/ContentView.swift
+++ b/Solstice/ContentView.swift
@@ -137,6 +137,10 @@ struct ContentView: View {
 						await NotificationManager.scheduleNotifications(location: currentLocation.location)
 				#endif
 				case .active:
+					// A suspended app misses the TimeMachine's minutely reference-date ticks;
+					// waking after hours would otherwise show the pre-sleep sky and sun position
+					// until the next tick lands.
+					timeMachine.updateReferenceDate()
 					// Skip the location-permission request during screenshot capture: on macOS
 					// its system dialog steals focus and hides the app window from the test runner.
 					if !ScreenshotLaunch.isCapturing {

--- a/Solstice/Detail View/DailyOverview.swift
+++ b/Solstice/Detail View/DailyOverview.swift
@@ -15,8 +15,6 @@ struct DailyOverview<Location: AnyLocation>: View {
 	var solar: NTSolar
 	var location: Location
 
-	@State private var gradientSolar: NTSolar?
-
 	@AppStorage(Preferences.detailViewChartAppearance) private var chartAppearance
 	@AppStorage(Preferences.chartType) private var chartType
 
@@ -219,10 +217,7 @@ extension DailyOverview {
 		#endif
 		#if !os(watchOS)
 		.if(chartAppearance == .graphical) { content in
-			content.skyChartBackground(solar: gradientSolar ?? solar)
-		}
-		.onPreferenceChange(DaylightGradientTimePreferenceKey.self) { date in
-			self.gradientSolar = NTSolar(for: date, coordinate: solar.coordinate, timeZone: location.timeZone)
+			content.skyChartBackground(solar: solar)
 		}
 		#endif
 		#if os(macOS)

--- a/Solstice/Detail View/DailyOverview.swift
+++ b/Solstice/Detail View/DailyOverview.swift
@@ -16,7 +16,6 @@ struct DailyOverview<Location: AnyLocation>: View {
 	var location: Location
 
 	@State private var gradientSolar: NTSolar?
-	@State private var skyChartGeometry: SkyChartGeometry?
 
 	@AppStorage(Preferences.detailViewChartAppearance) private var chartAppearance
 	@AppStorage(Preferences.chartType) private var chartType
@@ -220,45 +219,15 @@ extension DailyOverview {
 		#endif
 		#if !os(watchOS)
 		.if(chartAppearance == .graphical) { content in
-			content
-				.background {
-					GeometryReader { geo in
-						SkyGradient(ntSolar: gradientSolar ?? solar,
-						            sunAnchor: normalizedSunAnchor(in: geo),
-						            horizonFraction: normalizedHorizonFraction(in: geo))
-					}
-				}
-				.coordinateSpace(.named(SkyGradient.coordinateSpaceName))
+			content.skyChartBackground(solar: gradientSolar ?? solar)
 		}
 		.onPreferenceChange(DaylightGradientTimePreferenceKey.self) { date in
 			self.gradientSolar = NTSolar(for: date, coordinate: solar.coordinate, timeZone: location.timeZone)
-		}
-		.onPreferenceChange(SkyChartGeometryPreferenceKey.self) { geometry in
-			self.skyChartGeometry = geometry
 		}
 		#endif
 		#if os(macOS)
 		.padding(-12)
 		#endif
-	}
-
-	/// Converts the chart's reported sun position (in the shared coordinate space) into a
-	/// `UnitPoint` within the gradient background's own bounds.
-	private func normalizedSunAnchor(in geo: GeometryProxy) -> UnitPoint? {
-		guard let sunPoint = skyChartGeometry?.sunPoint else { return nil }
-		let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
-		guard frame.width > 0, frame.height > 0 else { return nil }
-		return UnitPoint(x: (sunPoint.x - frame.minX) / frame.width,
-		                 y: (sunPoint.y - frame.minY) / frame.height)
-	}
-
-	/// Converts the chart's reported horizon line (in the shared coordinate space) into a fraction
-	/// of the gradient background's own height, so the mesh renders ground below it.
-	private func normalizedHorizonFraction(in geo: GeometryProxy) -> Double? {
-		guard let horizonY = skyChartGeometry?.horizonY else { return nil }
-		let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
-		guard frame.height > 0 else { return nil }
-		return (horizonY - frame.minY) / frame.height
 	}
 }
 

--- a/Solstice/Detail View/DailyOverview.swift
+++ b/Solstice/Detail View/DailyOverview.swift
@@ -195,13 +195,25 @@ struct DailyOverview<Location: AnyLocation>: View {
 }
 
 extension DailyOverview {
+	/// Whether the chart gets the sky background and coordinate space (and so should publish its
+	/// geometry): graphical appearance on platforms where the background block below compiles.
+	private var isGraphicalWithSkyBackground: Bool {
+		#if os(watchOS)
+			return false
+		#else
+			return chartAppearance == .graphical
+		#endif
+	}
+
 	@ViewBuilder
 	var daylightChartView: some View {
 		DaylightChart(
 			solar: solar,
 			timeZone: location.timeZone,
 			appearance: chartAppearance, scrubbable: true,
-			markSize: chartMarkSize
+			markSize: chartMarkSize,
+			// Must mirror the condition that attaches the coordinate space below.
+			tracksSkyGeometry: isGraphicalWithSkyBackground
 		)
 		#if os(macOS)
 		.padding(12)

--- a/Solstice/Detail View/DailyOverview.swift
+++ b/Solstice/Detail View/DailyOverview.swift
@@ -16,7 +16,7 @@ struct DailyOverview<Location: AnyLocation>: View {
 	var location: Location
 
 	@State private var gradientSolar: NTSolar?
-	@State private var sunAnchorPoint: CGPoint?
+	@State private var skyChartGeometry: SkyChartGeometry?
 
 	@AppStorage(Preferences.detailViewChartAppearance) private var chartAppearance
 	@AppStorage(Preferences.chartType) private var chartType
@@ -211,7 +211,9 @@ extension DailyOverview {
 			content
 				.background {
 					GeometryReader { geo in
-						SkyGradient(ntSolar: gradientSolar ?? solar, sunAnchor: normalizedSunAnchor(in: geo))
+						SkyGradient(ntSolar: gradientSolar ?? solar,
+						            sunAnchor: normalizedSunAnchor(in: geo),
+						            horizonFraction: normalizedHorizonFraction(in: geo))
 					}
 				}
 				.coordinateSpace(.named(SkyGradient.coordinateSpaceName))
@@ -219,8 +221,8 @@ extension DailyOverview {
 		.onPreferenceChange(DaylightGradientTimePreferenceKey.self) { date in
 			self.gradientSolar = NTSolar(for: date, coordinate: solar.coordinate, timeZone: location.timeZone)
 		}
-		.onPreferenceChange(SkySunAnchorPreferenceKey.self) { point in
-			self.sunAnchorPoint = point
+		.onPreferenceChange(SkyChartGeometryPreferenceKey.self) { geometry in
+			self.skyChartGeometry = geometry
 		}
 		#endif
 		#if os(macOS)
@@ -231,11 +233,20 @@ extension DailyOverview {
 	/// Converts the chart's reported sun position (in the shared coordinate space) into a
 	/// `UnitPoint` within the gradient background's own bounds.
 	private func normalizedSunAnchor(in geo: GeometryProxy) -> UnitPoint? {
-		guard let sunAnchorPoint else { return nil }
+		guard let sunPoint = skyChartGeometry?.sunPoint else { return nil }
 		let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
 		guard frame.width > 0, frame.height > 0 else { return nil }
-		return UnitPoint(x: (sunAnchorPoint.x - frame.minX) / frame.width,
-		                 y: (sunAnchorPoint.y - frame.minY) / frame.height)
+		return UnitPoint(x: (sunPoint.x - frame.minX) / frame.width,
+		                 y: (sunPoint.y - frame.minY) / frame.height)
+	}
+
+	/// Converts the chart's reported horizon line (in the shared coordinate space) into a fraction
+	/// of the gradient background's own height, so the mesh renders ground below it.
+	private func normalizedHorizonFraction(in geo: GeometryProxy) -> Double? {
+		guard let horizonY = skyChartGeometry?.horizonY else { return nil }
+		let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
+		guard frame.height > 0 else { return nil }
+		return (horizonY - frame.minY) / frame.height
 	}
 }
 

--- a/Solstice/Detail View/DailyOverview.swift
+++ b/Solstice/Detail View/DailyOverview.swift
@@ -16,6 +16,7 @@ struct DailyOverview<Location: AnyLocation>: View {
 	var location: Location
 
 	@State private var gradientSolar: NTSolar?
+	@State private var sunAnchorPoint: CGPoint?
 
 	@AppStorage(Preferences.detailViewChartAppearance) private var chartAppearance
 	@AppStorage(Preferences.chartType) private var chartType
@@ -209,16 +210,32 @@ extension DailyOverview {
 		.if(chartAppearance == .graphical) { content in
 			content
 				.background {
-					SkyGradient(ntSolar: gradientSolar ?? solar)
+					GeometryReader { geo in
+						SkyGradient(ntSolar: gradientSolar ?? solar, sunAnchor: normalizedSunAnchor(in: geo))
+					}
 				}
+				.coordinateSpace(.named(SkyGradient.coordinateSpaceName))
 		}
 		.onPreferenceChange(DaylightGradientTimePreferenceKey.self) { date in
 			self.gradientSolar = NTSolar(for: date, coordinate: solar.coordinate, timeZone: location.timeZone)
+		}
+		.onPreferenceChange(SkySunAnchorPreferenceKey.self) { point in
+			self.sunAnchorPoint = point
 		}
 		#endif
 		#if os(macOS)
 		.padding(-12)
 		#endif
+	}
+
+	/// Converts the chart's reported sun position (in the shared coordinate space) into a
+	/// `UnitPoint` within the gradient background's own bounds.
+	private func normalizedSunAnchor(in geo: GeometryProxy) -> UnitPoint? {
+		guard let sunAnchorPoint else { return nil }
+		let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
+		guard frame.width > 0, frame.height > 0 else { return nil }
+		return UnitPoint(x: (sunAnchorPoint.x - frame.minX) / frame.width,
+		                 y: (sunAnchorPoint.y - frame.minY) / frame.height)
 	}
 }
 

--- a/Solstice/Detail View/DetailView.swift
+++ b/Solstice/Detail View/DetailView.swift
@@ -33,6 +33,12 @@ struct DetailView<Location: ObservableLocation>: View {
 		NTSolar(for: timeMachine.date, coordinate: location.coordinate, timeZone: location.timeZone)
 	}
 
+	/// Whether the sun is above the horizon at this location at the displayed (time-machine) date.
+	private var sunIsUp: Bool {
+		guard let solar else { return false }
+		return solar.altitude(at: solar.date) > 0
+	}
+
 	var navBarTitleText: Text {
 		let resolvedTitle = nameResolver?.displayName(for: location).title ?? location.title
 		guard let title = resolvedTitle else {
@@ -64,42 +70,51 @@ struct DetailView<Location: ObservableLocation>: View {
 					proxy.scrollTo(Self.annualAnchor, anchor: .top)
 				}
 			#endif
-				.navigationTitle(navBarTitleText)
-				.toolbar {
-					toolbarItems
-				}
-				.userActivity(Self.userActivity) { userActivity in
-					var navigationSelection: String? = nil
-
-					if let location = location as? SavedLocation {
-						navigationSelection = location.uuid?.uuidString
-					} else if let location = location as? CurrentLocation {
-						navigationSelection = location.id
-					}
-
-					userActivity.title = "See daylight for \(location is CurrentLocation ? "current location" : location.title ?? "location")"
-
-					userActivity.targetContentIdentifier = navigationSelection
-					userActivity.isEligibleForSearch = true
-					userActivity.isEligibleForHandoff = false
-				}
 			#if os(watchOS)
-				.modify {
-					if let solar {
-						$0.containerBackground(
-							SkyGradient(ntSolar: solar),
-							for: .navigation
-						)
-					} else {
-						$0
-					}
-				}
+			// The default tint-coloured title is low contrast against the daytime sky in the
+			// container background; while the sun is up here, use a sun yellow instead.
+			.navigationTitle {
+				navBarTitleText
+					.foregroundStyle(sunIsUp ? AnyShapeStyle(Color.yellow) : AnyShapeStyle(.tint))
+			}
+			#else
+			.navigationTitle(navBarTitleText)
 			#endif
-				.sheet(isPresented: $showShareSheet) {
-					if let solar {
-						ShareSolarChartView(solar: solar, location: location, chartAppearance: chartAppearance)
-					}
+			.toolbar {
+				toolbarItems
+			}
+			.userActivity(Self.userActivity) { userActivity in
+				var navigationSelection: String? = nil
+
+				if let location = location as? SavedLocation {
+					navigationSelection = location.uuid?.uuidString
+				} else if let location = location as? CurrentLocation {
+					navigationSelection = location.id
 				}
+
+				userActivity.title = "See daylight for \(location is CurrentLocation ? "current location" : location.title ?? "location")"
+
+				userActivity.targetContentIdentifier = navigationSelection
+				userActivity.isEligibleForSearch = true
+				userActivity.isEligibleForHandoff = false
+			}
+			#if os(watchOS)
+			.modify {
+				if let solar {
+					$0.containerBackground(
+						SkyGradient(ntSolar: solar),
+						for: .navigation
+					)
+				} else {
+					$0
+				}
+			}
+			#endif
+			.sheet(isPresented: $showShareSheet) {
+				if let solar {
+					ShareSolarChartView(solar: solar, location: location, chartAppearance: chartAppearance)
+				}
+			}
 		}
 	}
 

--- a/Solstice/Extensions/View+DaylightGradientTimePreferenceKey.swift
+++ b/Solstice/Extensions/View+DaylightGradientTimePreferenceKey.swift
@@ -16,3 +16,15 @@ struct DaylightGradientTimePreferenceKey: PreferenceKey {
 		value = nextValue()
 	}
 }
+
+/// The sun marker's position, in the `skyGradient` named coordinate space, published up from a chart
+/// so the `SkyGradient` background can anchor its glow to it. See `SkyGradient.coordinateSpaceName`.
+struct SkySunAnchorPreferenceKey: PreferenceKey {
+	typealias Value = CGPoint?
+
+	static let defaultValue: CGPoint? = nil
+
+	static func reduce(value: inout CGPoint?, nextValue: () -> CGPoint?) {
+		value = nextValue() ?? value
+	}
+}

--- a/Solstice/Extensions/View+DaylightGradientTimePreferenceKey.swift
+++ b/Solstice/Extensions/View+DaylightGradientTimePreferenceKey.swift
@@ -17,14 +17,18 @@ struct DaylightGradientTimePreferenceKey: PreferenceKey {
 	}
 }
 
-/// The sun marker's position, in the `skyGradient` named coordinate space, published up from a chart
-/// so the `SkyGradient` background can anchor its glow to it. See `SkyGradient.coordinateSpaceName`.
-struct SkySunAnchorPreferenceKey: PreferenceKey {
-	typealias Value = CGPoint?
+/// Geometry a chart publishes so its `SkyGradient` background can align with it: the sun marker's
+/// position (glow anchor) and the horizon line's y (sky/ground boundary), both in the `skyGradient`
+/// named coordinate space. See `SkyGradient.coordinateSpaceName`.
+struct SkyChartGeometry: Equatable {
+	var sunPoint: CGPoint?
+	var horizonY: CGFloat?
+}
 
-	static let defaultValue: CGPoint? = nil
+struct SkyChartGeometryPreferenceKey: PreferenceKey {
+	static let defaultValue: SkyChartGeometry? = nil
 
-	static func reduce(value: inout CGPoint?, nextValue: () -> CGPoint?) {
+	static func reduce(value: inout SkyChartGeometry?, nextValue: () -> SkyChartGeometry?) {
 		value = nextValue() ?? value
 	}
 }

--- a/Solstice/Extensions/View+DaylightGradientTimePreferenceKey.swift
+++ b/Solstice/Extensions/View+DaylightGradientTimePreferenceKey.swift
@@ -32,3 +32,37 @@ struct SkyChartGeometryPreferenceKey: PreferenceKey {
 		value = nextValue() ?? value
 	}
 }
+
+extension View {
+	/// Lays a sun-tracking `SkyGradient` behind a chart that publishes
+	/// `SkyChartGeometryPreferenceKey` (a `DaylightChart` with `tracksSkyGeometry: true`).
+	///
+	/// Stateless by design: the published geometry resolves into the background within the same
+	/// render pass, so the glow never trails the sun marker by a frame — and the whole assembly
+	/// works under `ImageRenderer`, where a preference → state → re-render loop would never run
+	/// (the share card renders in a detached tree that gets exactly one pass).
+	func skyChartBackground(solar: NTSolar?) -> some View {
+		backgroundPreferenceValue(SkyChartGeometryPreferenceKey.self) { geometry in
+			GeometryReader { geo in
+				let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
+				SkyGradient(ntSolar: solar,
+				            sunAnchor: normalizedAnchor(geometry?.sunPoint, in: frame),
+				            horizonFraction: normalizedHorizon(geometry?.horizonY, in: frame))
+			}
+		}
+		.coordinateSpace(.named(SkyGradient.coordinateSpaceName))
+	}
+}
+
+/// The chart reports positions in the shared coordinate space; the gradient wants fractions of
+/// its own bounds.
+private func normalizedAnchor(_ point: CGPoint?, in frame: CGRect) -> UnitPoint? {
+	guard let point, frame.width > 0, frame.height > 0 else { return nil }
+	return UnitPoint(x: (point.x - frame.minX) / frame.width,
+	                 y: (point.y - frame.minY) / frame.height)
+}
+
+private func normalizedHorizon(_ y: CGFloat?, in frame: CGRect) -> Double? {
+	guard let y, frame.height > 0 else { return nil }
+	return (y - frame.minY) / frame.height
+}

--- a/Solstice/Extensions/View+SkyChartGeometry.swift
+++ b/Solstice/Extensions/View+SkyChartGeometry.swift
@@ -1,5 +1,5 @@
 //
-//  View+DaylightGradientTimePreferenceKey.swift
+//  View+SkyChartGeometry.swift
 //  Solstice
 //
 //  Created by Daniel Eden on 04/03/2025.
@@ -7,20 +7,12 @@
 
 import SwiftUI
 
-struct DaylightGradientTimePreferenceKey: PreferenceKey {
-	typealias Value = Date
-
-	static let defaultValue: Date = .init()
-
-	static func reduce(value: inout Date, nextValue: () -> Date) {
-		value = nextValue()
-	}
-}
-
-/// Geometry a chart publishes so its `SkyGradient` background can align with it: the sun marker's
-/// position (glow anchor) and the horizon line's y (sky/ground boundary), both in the `skyGradient`
-/// named coordinate space. See `SkyGradient.coordinateSpaceName`.
+/// Geometry a chart publishes so its `SkyGradient` background can align with it: the plotted
+/// moment (the scrubbed time, when scrubbing), the sun marker's position (glow anchor), and the
+/// horizon line's y (sky/ground boundary) — points in the `skyGradient` named coordinate space.
+/// See `SkyGradient.coordinateSpaceName`.
 struct SkyChartGeometry: Equatable {
+	var date: Date?
 	var sunPoint: CGPoint?
 	var horizonY: CGFloat?
 }
@@ -45,7 +37,7 @@ extension View {
 		backgroundPreferenceValue(SkyChartGeometryPreferenceKey.self) { geometry in
 			GeometryReader { geo in
 				let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
-				SkyGradient(ntSolar: solar,
+				SkyGradient(ntSolar: skySolar(for: geometry?.date, basedOn: solar),
 				            sunAnchor: normalizedAnchor(geometry?.sunPoint, in: frame),
 				            horizonFraction: normalizedHorizon(geometry?.horizonY, in: frame))
 			}
@@ -65,4 +57,11 @@ private func normalizedAnchor(_ point: CGPoint?, in frame: CGRect) -> UnitPoint?
 private func normalizedHorizon(_ y: CGFloat?, in frame: CGRect) -> Double? {
 	guard let y, frame.height > 0 else { return nil }
 	return (y - frame.minY) / frame.height
+}
+
+/// The sky follows the *plotted* moment — while scrubbing, that's the scrubbed time rather than
+/// the chart's own date.
+private func skySolar(for date: Date?, basedOn solar: NTSolar?) -> NTSolar? {
+	guard let solar, let date, date != solar.date else { return solar }
+	return NTSolar(for: date, coordinate: solar.coordinate, timeZone: solar.timeZone)
 }

--- a/Solstice/Helper Views/ShareSolarChartView.swift
+++ b/Solstice/Helper Views/ShareSolarChartView.swift
@@ -44,13 +44,11 @@ struct ShareSolarChartView<Location: AnyLocation>: View {
 				solar: solar,
 				timeZone: location.timeZone,
 				appearance: chartAppearance, scrubbable: true,
-				markSize: chartMarkSize
+				markSize: chartMarkSize,
+				tracksSkyGeometry: chartAppearance == .graphical
 			)
 			.if(chartAppearance == .graphical) { content in
-				content
-					.background {
-						SkyGradient(ntSolar: solar)
-					}
+				content.skyChartBackground(solar: solar)
 			}
 		case .circular:
 			CircularSolarChart(date: solar.date, location: location, appearanceOverride: chartAppearance)

--- a/Solstice/Helper Views/ShareSolarChartView.swift
+++ b/Solstice/Helper Views/ShareSolarChartView.swift
@@ -284,6 +284,9 @@ struct ShareSolarChartView<Location: AnyLocation>: View {
 		}
 		.background(in: .rect(cornerRadius: 20, style: .continuous))
 		.frame(width: 420, height: 525)
+		// The renderer's tree is detached from the app hierarchy, so it inherits no environment;
+		// without this, charts fall back to the TimeMachine.default singleton.
+		.environment(\.timeMachine, timeMachine)
 
 		let imageRenderer = ImageRenderer(content: view)
 		imageRenderer.scale = 3

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -74,6 +74,28 @@ struct SkyModel {
 	/// Fraction of the sun's glow that shows through below the horizon — the ground keeps a hint
 	/// of the aureole rather than mirroring it.
 	var groundGlowTransmission = 0.2
+
+	/// Sunrise/sunset drama. All three ramp in as the sun approaches the horizon, at full
+	/// strength when it touches it and gone once |altitude| exceeds `glowDramaFalloffDeg`:
+	/// the glow gets brighter (`glowHorizonGain`), more saturated (`glowHorizonSaturation`),
+	/// and — on surfaces with a horizon line — stretches into an ellipse hugging it
+	/// (`glowHorizonStretch`, the horizontal scale at altitude 0).
+	var glowDramaFalloffDeg = 15.0
+	var glowHorizonGain = 0.4
+	var glowHorizonSaturation = 0.5
+	var glowHorizonStretch = 1.5
+
+	/// 0 far from the horizon → 1 as the sun touches it, from either side.
+	func horizonCloseness(sunAltitudeDeg: Double) -> Double {
+		max(0, 1 - abs(sunAltitudeDeg) / glowDramaFalloffDeg)
+	}
+
+	/// Horizontal scale for the glow layer: circular when the sun is high, stretched along the
+	/// horizon at sunrise/sunset.
+	func glowStretch(sunAltitudeDeg: Double) -> Double {
+		1 + (glowHorizonStretch - 1) * horizonCloseness(sunAltitudeDeg: sunAltitudeDeg)
+	}
+
 	/// View elevation sampled for the ground's illumination.
 	var groundSourceElevationDeg = 2.5
 	/// The ground reflects the whole sky dome, not just the horizon band. Blending the (bluer)
@@ -281,6 +303,13 @@ struct SkyModel {
 
 		let base = encoded(scatterCosTheta: ambientScatterCosTheta(sunAltitudeDeg: sunAltitudeDeg,
 		                                                           viewElevationDeg: elevationDeg))
+
+		// Sunrise/sunset drama: brighten and saturate the aureole as the sun nears the horizon —
+		// the physics alone underplays it after tone-mapping.
+		let closeness = horizonCloseness(sunAltitudeDeg: sunAltitudeDeg)
+		let gain = 1 + glowHorizonGain * closeness
+		let saturation = 1 + glowHorizonSaturation * closeness
+
 		return (0 ..< stopCount).map { i in
 			// Quadratic spacing clusters stops in the tight forward lobe near the centre.
 			let t = Double(i) / Double(stopCount - 1)
@@ -290,10 +319,15 @@ struct SkyModel {
 			// gamma-space difference against the ambient base: base + glow reconstructs the
 			// sun-facing sky exactly where they meet.
 			let lit = encoded(scatterCosTheta: cos(min(.pi, angle)))
+			let glow = SIMD3<Double>(max(0, lit.x - base.x),
+			                         max(0, lit.y - base.y),
+			                         max(0, lit.z - base.z))
+			let luminance = 0.2126 * glow.x + 0.7152 * glow.y + 0.0722 * glow.z
+			let dramatic = (SIMD3<Double>(repeating: luminance) + (glow - SIMD3<Double>(repeating: luminance)) * saturation) * gain
 			return Gradient.Stop(color: Color(.sRGB,
-			                                  red: max(0, lit.x - base.x),
-			                                  green: max(0, lit.y - base.y),
-			                                  blue: max(0, lit.z - base.z)),
+			                                  red: min(1, max(0, dramatic.x)),
+			                                  green: min(1, max(0, dramatic.y)),
+			                                  blue: min(1, max(0, dramatic.z))),
 			                     location: location)
 		}
 	}
@@ -627,6 +661,11 @@ struct SkyView: View {
 					               center: sunAnchor,
 					               startRadius: 0,
 					               endRadius: max(geo.size.width, geo.size.height))
+						// At sunrise/sunset the aureole stretches along the horizon rather than
+						// staying circular — but only on surfaces that *have* a horizon; the dial's
+						// day wedge and ambient skies keep the round glow.
+						.scaleEffect(x: horizonFraction == nil ? 1 : SkyModel.standard.glowStretch(sunAltitudeDeg: sunAltitudeDeg),
+						             anchor: sunAnchor)
 				}
 				.mask { glowMask }
 				// Blend applied last: inside the mask's compositing group there is no backdrop,
@@ -636,6 +675,9 @@ struct SkyView: View {
 			}
 		}
 		.compositingGroup()
+		// The stretched glow extends past the view horizontally; don't let it bleed into
+		// neighbouring content.
+		.clipped()
 	}
 
 	/// Only a hint of the aureole survives below the horizon.

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -257,13 +257,18 @@ struct SkyModel {
 	/// looking `r · glowAngularScaleDeg` away from the sun, *minus* the ambient base the glow is
 	/// layered over with `.plusLighter` — so mesh + glow ≈ the fully sun-anchored sky, but with
 	/// per-pixel smoothness and a continuously movable centre.
-	func glowStops(sunAltitudeDeg: Double, stopCount: Int = 12) -> [Gradient.Stop] {
-		// Coarser march, like the dial: the glow is the difference of two similar skies, so fine
-		// sampling washes out of the result anyway.
+	/// This model with a coarser ray march, for callers that evaluate many directions (the dial
+	/// ring, the glow stops): colour varies smoothly enough with angle that the difference is
+	/// invisible after tone-mapping.
+	private var coarseMarch: SkyModel {
 		var coarse = self
 		coarse.viewSamples = 8
 		coarse.lightSamples = 4
+		return coarse
+	}
 
+	func glowStops(sunAltitudeDeg: Double, stopCount: Int = 12) -> [Gradient.Stop] {
+		let coarse = coarseMarch
 		let elevationDeg = max(sunAltitudeDeg, groundSourceElevationDeg)
 
 		func encoded(scatterCosTheta: Double) -> SIMD3<Double> {
@@ -300,16 +305,30 @@ struct SkyModel {
 
 	/// Vertical mesh layout: each row's y position and what it samples. Without a horizon the strip
 	/// is all sky; with one, the sky compresses above it and the remainder renders as ground.
+	/// Where a horizon can meaningfully split the view: below the range the ground would swallow
+	/// the sky, above it the band falls off the bottom edge. Chart geometry arrives unclamped —
+	/// during polar day/night the fitted y-scale extrapolates the horizon outside the view
+	/// entirely — so both the mesh and the glow mask normalise through `visibleHorizon` and always
+	/// agree about where, and whether, the horizon is.
+	static let horizonRange = 0.08 ... 0.92
+	/// Height of the sky→ground transition, as a fraction of the view: the first ground row (and
+	/// the glow mask's cut) sit this far below the horizon, so the edge reads crisp.
+	static let horizonEdgeWidth = 0.004
+
+	func visibleHorizon(_ fraction: Double?) -> Double? {
+		guard let fraction, fraction < Self.horizonRange.upperBound else { return nil }
+		return max(fraction, Self.horizonRange.lowerBound)
+	}
+
 	private func rowLayout(horizonFraction: Double?) -> [(y: Double, content: RowContent)] {
-		// A horizon at (or beyond) the bottom edge leaves no room for a ground band — all sky.
-		guard let horizonFraction, horizonFraction < 0.92 else {
+		// No visible horizon: all sky.
+		guard let hf = visibleHorizon(horizonFraction) else {
 			return (0 ..< meshHeight).map { row in
 				let y = Double(row) / Double(meshHeight - 1)
 				return (y, .sky(elevationDeg: minElevationDeg + (maxElevationDeg - minElevationDeg) * (1 - y)))
 			}
 		}
 
-		let hf = max(horizonFraction, 0.08)
 		let skyRows = meshHeight - 2
 		var rows: [(y: Double, content: RowContent)] = (0 ..< skyRows).map { row in
 			let fraction = Double(row) / Double(skyRows - 1)
@@ -319,7 +338,7 @@ struct SkyModel {
 		// The first ground row sits almost on top of the last sky row, so the sky→ground transition
 		// spans a fraction of a point and the horizon reads as a crisp edge exactly on the chart's
 		// horizon line; the bottom row fades the ground out.
-		rows.append((y: hf + 0.004, content: .ground(reflectance: groundReflectance)))
+		rows.append((y: hf + Self.horizonEdgeWidth, content: .ground(reflectance: groundReflectance)))
 		rows.append((y: 1, content: .ground(reflectance: groundReflectance * 0.4)))
 		return rows
 	}
@@ -372,11 +391,7 @@ struct SkyModel {
 	/// steps darker toward night — the Watch solar dial look. Stop locations are fractions of a day
 	/// from midnight; align them using the chart's midnight angle.
 	func dialStops(for solar: NTSolar, sampleCount: Int = 48) -> [Gradient.Stop] {
-		// Coarser march than the mesh: the dial evaluates many directions, and colour varies smoothly
-		// enough with altitude that the difference is invisible after tone-mapping.
-		var coarse = self
-		coarse.viewSamples = 8
-		coarse.lightSamples = 4
+		let coarse = coarseMarch
 
 		// The wedges brighten with the daylight at the *current* moment, not the wedge's own time.
 		let daylight = daylightFactor(sunAltitudeDeg: solar.altitude(at: solar.date))
@@ -499,6 +514,11 @@ struct SkyModel {
 /// scrolling while the inputs barely move. Memoizing keeps unchanged frames at the cost of a
 /// dictionary lookup. Lock-guarded rather than actor-isolated because bodies aren't guaranteed
 /// a single thread across targets.
+/// Xcode Previews hot-swap code into a persistent host process, so memoized colours would outlive
+/// edits to the model's constants and show stale skies while tuning. Previews render uncached
+/// instead. Stored once: this guards every cache access on the render path.
+private let skyCachesBypassedForPreviews = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+
 final class SkyRenderCache<Key: Hashable, Value>: @unchecked Sendable {
 	private var store = [Key: Value]()
 	private let lock = NSLock()
@@ -508,15 +528,8 @@ final class SkyRenderCache<Key: Hashable, Value>: @unchecked Sendable {
 		self.capacity = capacity
 	}
 
-	/// Xcode Previews hot-swap code into a persistent host process, so memoized colours would
-	/// outlive edits to the model's constants and show stale skies while tuning. Previews render
-	/// uncached instead.
-	private static var isRunningForPreviews: Bool {
-		ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
-	}
-
 	func value(for key: Key, compute: () -> Value) -> Value {
-		guard !Self.isRunningForPreviews else { return compute() }
+		guard !skyCachesBypassedForPreviews else { return compute() }
 
 		lock.lock()
 		if let cached = store[key] {
@@ -628,11 +641,13 @@ struct SkyView: View {
 	/// Only a hint of the aureole survives below the horizon.
 	@ViewBuilder
 	private var glowMask: some View {
-		if let horizonFraction {
+		// Normalised through the same rule as the mesh, so the mask never dims below a horizon
+		// the mesh doesn't draw.
+		if let horizon = SkyModel.standard.visibleHorizon(horizonFraction) {
 			LinearGradient(stops: [
 				.init(color: .white, location: 0),
-				.init(color: .white, location: horizonFraction),
-				.init(color: .white.opacity(SkyModel.standard.groundGlowTransmission), location: horizonFraction + 0.004),
+				.init(color: .white, location: horizon),
+				.init(color: .white.opacity(SkyModel.standard.groundGlowTransmission), location: horizon + SkyModel.horizonEdgeWidth),
 			], startPoint: .top, endPoint: .bottom)
 		} else {
 			Color.white

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -53,13 +53,25 @@ struct SkyModel {
 	var meshWidth = 9
 	var meshHeight = 7
 	/// View elevations sampled at the bottom and top of the rendered strip, in degrees. Keeping the
-	/// bottom above the horizon avoids the muddy long-path haze and gives a calmer, more even ramp;
-	/// the dramatic below-horizon darkening is applied by the chart, which knows the horizon line.
+	/// bottom above the horizon avoids the muddy long-path haze and gives a calmer, more even ramp.
 	var minElevationDeg = 6.0
 	var maxElevationDeg = 45.0
 	/// Degrees of scattering angle per unit of normalised distance from the sun anchor.
 	/// Higher values shrink the glow; lower values spread it across the gradient.
 	var glowAngularScaleDeg = 120.0
+
+	/// Below a horizon there is no sky to march — only ground. The ground band renders as the sky
+	/// just above the horizon reflected darkly, so twilight's warm band carries into it. This is the
+	/// fraction of that light reflected right at the horizon; it fades further with depth.
+	var groundReflectance = 0.3
+	/// View elevation sampled for the ground's illumination.
+	var groundSourceElevationDeg = 2.5
+
+	/// The dial ring (circular chart) samples the sky at this view elevation…
+	var dialViewElevationDeg = 12.0
+	/// …looking this far from the sun (as a cosine, ~30°), so sunrise and sunset arcs glow warmly
+	/// without the full aureole washing out the daytime blue.
+	var dialScatterCosTheta = 0.87
 
 	static let standard = SkyModel()
 
@@ -154,27 +166,33 @@ struct SkyModel {
 	/// - Parameters:
 	///   - sunAltitudeDeg: Sun altitude above the horizon, in degrees.
 	///   - sunAnchor: The sun's position in the gradient's own bounds (0…1, y-down).
-	func mesh(sunAltitudeDeg: Double, sunAnchor: UnitPoint) -> (gradient: MeshGradient, stops: [Color]) {
-		let w = meshWidth, h = meshHeight
+	///   - horizonFraction: The horizon line's vertical position in the gradient's bounds (0…1,
+	///     y-down). When set, rows below it render as ground instead of sky, with two rows placed
+	///     tight under the line so the horizon reads as a defined edge across the full width.
+	func mesh(sunAltitudeDeg: Double, sunAnchor: UnitPoint, horizonFraction: Double? = nil) -> (gradient: MeshGradient, stops: [Color]) {
+		let rows = rowLayout(horizonFraction: horizonFraction)
+		let w = meshWidth, h = rows.count
 
 		var points = [SIMD2<Float>]()
 		var colors = [Color]()
 		points.reserveCapacity(w * h)
 		colors.reserveCapacity(w * h)
 
-		for row in 0 ..< h {
-			let rowY = Double(row) / Double(h - 1)
-			let elevationFraction = 1 - rowY
-			// Even ramp between the horizon-ish bottom and the higher top.
-			let elevation = minElevationDeg + (maxElevationDeg - minElevationDeg) * elevationFraction
+		for (rowY, content) in rows {
 			for col in 0 ..< w {
 				let colX = Double(col) / Double(w - 1)
 				let distance = hypot(colX - Double(sunAnchor.x), rowY - Double(sunAnchor.y))
-				let scatterAngle = distance * glowAngularScaleDeg * .pi / 180
-				// Below the horizon the physical sky darkens to black — no artificial night floor.
-				let vertexColor = color(sunAltitudeDeg: sunAltitudeDeg,
-				                        viewElevationDeg: elevation,
-				                        scatterCosTheta: cos(scatterAngle))
+				let scatterCosTheta = cos(distance * glowAngularScaleDeg * .pi / 180)
+				let vertexColor: Color = switch content {
+				case let .sky(elevationDeg):
+					color(sunAltitudeDeg: sunAltitudeDeg,
+					      viewElevationDeg: elevationDeg,
+					      scatterCosTheta: scatterCosTheta)
+				case let .ground(reflectance):
+					groundColor(sunAltitudeDeg: sunAltitudeDeg,
+					            scatterCosTheta: scatterCosTheta,
+					            reflectance: reflectance)
+				}
 				points.append(SIMD2<Float>(Float(colX), Float(rowY)))
 				colors.append(vertexColor)
 			}
@@ -183,11 +201,78 @@ struct SkyModel {
 		let gradient = MeshGradient(width: w, height: h, points: points, colors: colors,
 		                            smoothsColors: true, colorSpace: .perceptual)
 
-		// Vertical ramp of the column farthest from the sun (first = zenith, last = horizon).
+		// Vertical ramp of the column farthest from the sun (first = zenith, last = horizon/ground).
 		let farColumn = sunAnchor.x < 0.5 ? w - 1 : 0
 		let stops = (0 ..< h).map { colors[$0 * w + farColumn] }
 
 		return (gradient, stops)
+	}
+
+	private enum RowContent {
+		case sky(elevationDeg: Double)
+		case ground(reflectance: Double)
+	}
+
+	/// Vertical mesh layout: each row's y position and what it samples. Without a horizon the strip
+	/// is all sky; with one, the sky compresses above it and the remainder renders as ground.
+	private func rowLayout(horizonFraction: Double?) -> [(y: Double, content: RowContent)] {
+		// A horizon at (or beyond) the bottom edge leaves no room for a ground band — all sky.
+		guard let horizonFraction, horizonFraction < 0.92 else {
+			return (0 ..< meshHeight).map { row in
+				let y = Double(row) / Double(meshHeight - 1)
+				return (y, .sky(elevationDeg: minElevationDeg + (maxElevationDeg - minElevationDeg) * (1 - y)))
+			}
+		}
+
+		let hf = max(horizonFraction, 0.08)
+		let skyRows = meshHeight - 2
+		var rows: [(y: Double, content: RowContent)] = (0 ..< skyRows).map { row in
+			let fraction = Double(row) / Double(skyRows - 1)
+			return (y: hf * fraction,
+			        content: .sky(elevationDeg: maxElevationDeg + (minElevationDeg - maxElevationDeg) * fraction))
+		}
+		// A row tight under the horizon gives it a defined edge; the bottom row fades the ground out.
+		rows.append((y: hf + 0.02, content: .ground(reflectance: groundReflectance)))
+		rows.append((y: 1, content: .ground(reflectance: groundReflectance * 0.4)))
+		return rows
+	}
+
+	/// Ground: the sky just above the horizon, reflected darkly. Twilight's warm horizon band carries
+	/// into it, and the shared ambient floor keeps it no darker than the night sky — so chart content
+	/// drawn over it stays legible.
+	private func groundColor(sunAltitudeDeg: Double, scatterCosTheta: Double, reflectance: Double) -> Color {
+		let source = radiance(sunAltitudeDeg: sunAltitudeDeg,
+		                      viewElevationDeg: groundSourceElevationDeg,
+		                      scatterCosTheta: scatterCosTheta)
+		return tonemap(source * reflectance + ambientRadiance)
+	}
+
+	// MARK: Dial
+
+	/// Sky colours around a 24-hour dial, for circular charts: each angle is coloured by the sky at
+	/// that time of day, so day, each twilight band, and night appear as arcs in their true positions.
+	/// Stop locations are fractions of a day from midnight; align them using the chart's midnight angle.
+	func dialStops(for solar: NTSolar, sampleCount: Int = 48) -> [Gradient.Stop] {
+		// Coarser march than the mesh: the dial evaluates many directions, and colour varies smoothly
+		// enough with altitude that the difference is invisible after tone-mapping.
+		var coarse = self
+		coarse.viewSamples = 8
+		coarse.lightSamples = 4
+
+		let start = solar.startOfDay
+		var stops = (0 ..< sampleCount).map { i in
+			let fraction = Double(i) / Double(sampleCount)
+			let date = start.addingTimeInterval(fraction * .twentyFourHours)
+			let color = coarse.color(sunAltitudeDeg: solar.altitude(at: date),
+			                         viewElevationDeg: dialViewElevationDeg,
+			                         scatterCosTheta: dialScatterCosTheta)
+			return Gradient.Stop(color: color, location: fraction)
+		}
+		// Close the ring seamlessly.
+		if let first = stops.first {
+			stops.append(Gradient.Stop(color: first.color, location: 1))
+		}
+		return stops
 	}
 
 	// MARK: Helpers
@@ -237,7 +322,7 @@ struct SkyModel {
 
 struct SkyGradient: View, ShapeStyle {
 	/// Named coordinate space shared between a chart and its `SkyGradient` background so the sun
-	/// marker's position can be reported via `SkySunAnchorPreferenceKey` and normalised consistently.
+	/// marker's geometry can be reported via `SkyChartGeometryPreferenceKey` and normalised consistently.
 	static let coordinateSpaceName = "skyGradient"
 
 	@Environment(\.timeZone) var timeZone
@@ -247,6 +332,11 @@ struct SkyGradient: View, ShapeStyle {
 	/// Where the sun sits in this gradient's own bounds (0…1, y-down). Callers with chart geometry
 	/// supply the sun marker's position; when `nil` the glow falls back to a time + altitude default.
 	var sunAnchor: UnitPoint? = nil
+
+	/// The horizon line's vertical position in this gradient's own bounds (0…1, y-down). When set,
+	/// the mesh renders ground below it; when `nil` (ambient surfaces like the watch container
+	/// background or widgets) the gradient is all sky.
+	var horizonFraction: Double? = nil
 
 	private var effectiveSolar: NTSolar? {
 		if let ntSolar {
@@ -259,7 +349,9 @@ struct SkyGradient: View, ShapeStyle {
 		let solar = effectiveSolar
 		let date = solar?.date ?? .now
 		let sunAltitude = solar?.altitude(at: date) ?? 0
-		return SkyModel.standard.mesh(sunAltitudeDeg: sunAltitude, sunAnchor: sunAnchor ?? defaultAnchor(for: solar, at: date, altitude: sunAltitude))
+		return SkyModel.standard.mesh(sunAltitudeDeg: sunAltitude,
+		                              sunAnchor: sunAnchor ?? defaultAnchor(for: solar, at: date, altitude: sunAltitude),
+		                              horizonFraction: horizonFraction)
 	}
 
 	/// A sensible glow position for surfaces with no chart geometry: horizontally at the sun's
@@ -340,7 +432,7 @@ private struct AltitudeSweepPreview: View {
 			ForEach(Array(altitudes), id: \.self) { altitude in
 				ZStack {
 					SkyModel.standard.mesh(sunAltitudeDeg: altitude, sunAnchor: .center).gradient
-					Text("\(Int(altitude))°")
+					Text(verbatim: "\(Int(altitude))°")
 						.font(.headline.monospacedDigit())
 						.foregroundStyle(.white)
 						.shadow(radius: 2)
@@ -362,11 +454,11 @@ private struct SkyModelSliderPreview: View {
 				.ignoresSafeArea()
 				.overlay(alignment: .bottom) {
 					VStack(alignment: .leading) {
-						Text("Altitude \(altitude, format: .number.precision(.fractionLength(1)))°")
+						Text(verbatim: "Altitude \(altitude.formatted(.number.precision(.fractionLength(1))))°")
 						Slider(value: $altitude, in: -20 ... 90)
-						Text("Anchor X \(anchorX, format: .number.precision(.fractionLength(2)))")
+						Text(verbatim: "Anchor X \(anchorX.formatted(.number.precision(.fractionLength(2))))")
 						Slider(value: $anchorX, in: 0 ... 1)
-						Text("Anchor Y \(anchorY, format: .number.precision(.fractionLength(2)))")
+						Text(verbatim: "Anchor Y \(anchorY.formatted(.number.precision(.fractionLength(2))))")
 						Slider(value: $anchorY, in: 0 ... 1)
 					}
 					.padding()

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -25,14 +25,20 @@ import SwiftUI
 /// tuning is a matter of changing `standard`'s values rather than the algorithm.
 struct SkyModel {
 	/// Rayleigh scattering coefficient per RGB wavelength (1/m).
-	var rayleigh = SIMD3<Double>(5.8e-6, 13.5e-6, 33.1e-6)
+	var rayleigh = SIMD3<Double>(3.8e-6, 11.5e-6, 38.1e-6)
 	/// Mie scattering coefficient (1/m). Lower keeps the daytime sky bluer and the horizon cleaner
 	/// (less neutral aerosol haze).
-	var mie = 13e-6
+	var mie = 8e-6
 	/// Henyey–Greenstein asymmetry: how tightly the Mie glow hugs the sun (0…1).
-	var mieG = 0.76
+	var mieG = 0.8
 	/// Ozone absorption per RGB wavelength (1/m) — deepens twilight blues and purples.
 	var ozone = SIMD3<Double>(0.650e-6, 1.881e-6, 0.085e-6)
+	/// Single scattering alone leaves long near-horizon paths yellow-green under a high sun: blue is
+	/// scattered out of the ray faster than in, and with no second bounce nothing replaces it. This
+	/// approximates multiple scattering with an isotropic, sky-tinted fill wherever the view path is
+	/// optically thick, fading with sun altitude so twilight and night keep their single-scatter
+	/// colours. Higher = paler, bluer horizon at midday.
+	var multipleScattering = 0.02
 
 	var rayleighScaleHeight = 8000.0
 	var mieScaleHeight = 1200.0
@@ -65,6 +71,10 @@ struct SkyModel {
 	/// fraction of that light reflected right at the horizon (in display-linear space, after
 	/// tone-mapping); it fades further with depth.
 	var groundReflectance = 0.12
+	/// Extra scattering angle added to ground vertices, pushing the reflected glow out of the tight
+	/// forward-Mie lobe: the ground keeps a hint of warmth under the sun instead of mirroring the
+	/// full aureole below the horizon.
+	var groundGlowAngularOffsetDeg = 30.0
 	/// View elevation sampled for the ground's illumination.
 	var groundSourceElevationDeg = 2.5
 
@@ -74,9 +84,10 @@ struct SkyModel {
 
 	/// The dial ring (circular chart) samples the sky at this view elevation…
 	var dialViewElevationDeg = 12.0
-	/// …looking this far from the sun (as a cosine, ~30°), so sunrise and sunset arcs glow warmly
-	/// without the full aureole washing out the daytime blue.
-	var dialScatterCosTheta = 0.87
+	/// …looking this far from the sun (as a cosine, ~60°). Only the night and twilight arcs of the
+	/// ring stay visible beneath the dynamic day wedge, so this is deliberately wide: the twilight
+	/// arcs keep their transmittance-driven colour without showing the sun's aureole itself.
+	var dialScatterCosTheta = 0.5
 
 	static let standard = SkyModel()
 
@@ -150,7 +161,16 @@ struct SkyModel {
 
 		let inRayleigh = rayleigh * sumR * phaseR
 		let inMie = sumM * (mie * phaseM)
-		return (inRayleigh + inMie) * sunIntensity
+
+		// Multiple-scattering fill: strongest where the view path has extinguished the single-
+		// scattered light (1 - transmittance), tinted like the scattering medium itself so it
+		// reads as pale blue rather than the yellow-green the extinguished path leaves behind.
+		let tauView = rayleigh * odR + SIMD3<Double>(repeating: mieExt * odM) + ozone * odO
+		let pathOpacity = SIMD3<Double>(1 - exp(-tauView.x), 1 - exp(-tauView.y), 1 - exp(-tauView.z))
+		let skyTint = rayleigh / simd_reduce_max(rayleigh)
+		let inMultiple = multipleScattering * max(0, sin(sa)) * pathOpacity * skyTint
+
+		return (inRayleigh + inMie + inMultiple) * sunIntensity
 	}
 
 	/// Tone-mapped, gamma-encoded sky colour for a view direction, including the ambient skylight floor.
@@ -189,10 +209,16 @@ struct SkyModel {
 			case let .sky(elevationDeg): elevationDeg
 			case .ground: groundSourceElevationDeg
 			}
+			// Ground vertices widen their scattering angle so the reflected glow falls outside the
+			// tight forward-Mie lobe — only a hint of the aureole survives below the horizon.
+			let groundOffset: Double = switch content {
+			case .sky: 0
+			case .ground: groundGlowAngularOffsetDeg * .pi / 180
+			}
 			for col in 0 ..< w {
 				let colX = Double(col) / Double(w - 1)
 				let scatterCosTheta: Double = if let sunAnchor {
-					cos(hypot(colX - Double(sunAnchor.x), rowY - Double(sunAnchor.y)) * glowAngularScaleDeg * .pi / 180)
+					cos(min(.pi, hypot(colX - Double(sunAnchor.x), rowY - Double(sunAnchor.y)) * glowAngularScaleDeg * .pi / 180 + groundOffset))
 				} else {
 					ambientScatterCosTheta(sunAltitudeDeg: sunAltitudeDeg, viewElevationDeg: elevationDeg)
 				}

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -462,24 +462,63 @@ struct SkyModel {
 			return Gradient.Stop(color: stopColor(altitudeDeg: solar.altitude(at: date)), location: fraction)
 		}
 
-		// Crisp wedge edges: a pair of near-coincident stops at each twilight boundary, coloured
-		// for the band on each side. Which side is the darker band depends on whether the sun is
-		// rising or setting there.
-		let boundaries: [(date: Date?, thresholdDeg: Double)] = [
-			(solar.sunrise, 0), (solar.sunset, 0),
-			(solar.civilSunrise, -6), (solar.civilSunset, -6),
-			(solar.nauticalSunrise, -12), (solar.nauticalSunset, -12),
-			(solar.astronomicalSunrise, -18), (solar.astronomicalSunset, -18),
+		// Crisp wedge edges: a near-coincident pair of stops pins each twilight boundary. Pairs
+		// sit on NTSolar's event dates whenever those exist, so the colour edges land exactly on
+		// the dial's phase lines and markers, which draw from the same dates. Where a named event
+		// doesn't exist (extreme latitudes/seasons), the crossing is bisected from the altitude
+		// curve instead — otherwise the band flip would smear across a whole sample interval.
+		var boundaries: [(fraction: Double, thresholdDeg: Double, rising: Bool)] = []
+		let events: [(date: Date?, thresholdDeg: Double, rising: Bool)] = [
+			(solar.sunrise, 0, true), (solar.sunset, 0, false),
+			(solar.civilSunrise, -6, true), (solar.civilSunset, -6, false),
+			(solar.nauticalSunrise, -12, true), (solar.nauticalSunset, -12, false),
+			(solar.astronomicalSunrise, -18, true), (solar.astronomicalSunset, -18, false),
 		]
-		for (date, thresholdDeg) in boundaries {
-			guard let date else { continue }
+		for event in events {
+			guard let date = event.date else { continue }
 			let fraction = date.timeIntervalSince(start) / .twentyFourHours
 			guard fraction > 0, fraction < 1 else { continue }
-			let rising = solar.altitude(at: date.addingTimeInterval(600)) > solar.altitude(at: date.addingTimeInterval(-600))
-			let earlier = stopColor(altitudeDeg: thresholdDeg + (rising ? -0.5 : 0.5))
-			let later = stopColor(altitudeDeg: thresholdDeg + (rising ? 0.5 : -0.5))
-			stops.append(Gradient.Stop(color: earlier, location: fraction - 0.0001))
-			stops.append(Gradient.Stop(color: later, location: fraction + 0.0001))
+			boundaries.append((fraction, event.thresholdDeg, event.rising))
+		}
+
+		let sampleSpacing = 1.0 / Double(sampleCount)
+		let thresholds: [Double] = [0, -6, -12, -18]
+		for sample in 0 ..< sampleCount {
+			let f0 = Double(sample) * sampleSpacing
+			let f1 = f0 + sampleSpacing
+			let a0 = solar.altitude(at: start.addingTimeInterval(f0 * .twentyFourHours))
+			let a1 = solar.altitude(at: start.addingTimeInterval(f1 * .twentyFourHours))
+			for threshold in thresholds where (a0 - threshold) * (a1 - threshold) < 0 {
+				let alreadyPinned = boundaries.contains {
+					$0.thresholdDeg == threshold && abs($0.fraction - (f0 + f1) / 2) <= sampleSpacing
+				}
+				guard !alreadyPinned else { continue }
+				var low = f0, high = f1
+				for _ in 0 ..< 20 {
+					let mid = (low + high) / 2
+					let altitude = solar.altitude(at: start.addingTimeInterval(mid * .twentyFourHours))
+					if (altitude - threshold) * (a0 - threshold) > 0 {
+						low = mid
+					} else {
+						high = mid
+					}
+				}
+				boundaries.append(((low + high) / 2, threshold, a1 > a0))
+			}
+		}
+
+		// An event date and the altitude crossing can differ by a minute or two (refraction,
+		// solver differences); a uniform sample landing in that sliver would repaint the old band
+		// past the pinned edge. Drop samples that crowd a boundary — the pair defines the edge.
+		stops.removeAll { stop in
+			boundaries.contains { abs($0.fraction - stop.location) < sampleSpacing / 2 }
+		}
+
+		for boundary in boundaries {
+			let earlier = stopColor(altitudeDeg: boundary.thresholdDeg + (boundary.rising ? -0.5 : 0.5))
+			let later = stopColor(altitudeDeg: boundary.thresholdDeg + (boundary.rising ? 0.5 : -0.5))
+			stops.append(Gradient.Stop(color: earlier, location: max(0, boundary.fraction - 0.0001)))
+			stops.append(Gradient.Stop(color: later, location: min(1, boundary.fraction + 0.0001)))
 		}
 
 		stops.sort { $0.location < $1.location }

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -45,36 +45,41 @@ struct SkyModel {
 	var viewSamples = 16
 	var lightSamples = 8
 
-	/// Mesh dimensions. More columns tighten the sun glow; more rows sharpen the horizon band.
-	var meshWidth = 7
-	var meshHeight = 5
+	/// Mesh dimensions. A denser grid renders the 2-D sun glow more smoothly.
+	var meshWidth = 9
+	var meshHeight = 7
 	/// Highest view elevation sampled (top of the rendered strip), in degrees.
 	var maxElevationDeg = 60.0
-	/// Horizontal degrees of azimuth spanned across the full width of the gradient.
-	var azimuthSpanDeg = 180.0
+	/// Degrees of scattering angle per unit of normalised distance from the sun anchor.
+	/// Higher values shrink the glow; lower values spread it across the gradient.
+	var glowAngularScaleDeg = 120.0
 
 	static let standard = SkyModel()
 
 	// MARK: Radiance
 
 	/// Linear (pre-tone-map) RGB radiance for a view direction, given the sun's altitude.
+	///
+	/// The atmosphere is spherically symmetric, so the ray-march path lengths depend only on the
+	/// view elevation and the sun altitude — the view's azimuth only ever entered through the phase
+	/// functions. Supplying `scatterCosTheta` directly lets the mesh place the glow anywhere (e.g. at
+	/// a chart's sun marker) without pretending the sky is a literal dome.
 	/// - Parameters:
 	///   - sunAltitudeDeg: Sun altitude above the horizon, in degrees (negative below).
 	///   - viewElevationDeg: View elevation above the horizon, in degrees.
-	///   - relativeAzimuthDeg: View azimuth relative to the sun, in degrees (0 = toward the sun).
-	func radiance(sunAltitudeDeg: Double, viewElevationDeg: Double, relativeAzimuthDeg: Double) -> SIMD3<Double> {
+	///   - scatterCosTheta: Cosine of the angle between the view ray and the sun (1 = straight at it).
+	func radiance(sunAltitudeDeg: Double, viewElevationDeg: Double, scatterCosTheta: Double) -> SIMD3<Double> {
 		let sa = sunAltitudeDeg * .pi / 180
 		let ve = viewElevationDeg * .pi / 180
-		let raz = relativeAzimuthDeg * .pi / 180
 
-		// Sun's horizontal azimuth is +x, up is +y.
+		// Up is +y; both rays live in the x-y plane since only their path lengths matter here.
 		let sun = SIMD3<Double>(cos(sa), sin(sa), 0)
-		let view = SIMD3<Double>(cos(ve) * cos(raz), sin(ve), cos(ve) * sin(raz))
+		let view = SIMD3<Double>(cos(ve), sin(ve), 0)
 		let origin = SIMD3<Double>(0, planetRadius, 0)
 
 		guard let tMax = raySphereFar(origin, view, atmosphereRadius) else { return .zero }
 
-		let cosTheta = simd_dot(view, sun)
+		let cosTheta = min(max(scatterCosTheta, -1), 1)
 		let phaseR = 3.0 / (16.0 * .pi) * (1 + cosTheta * cosTheta)
 		let g = mieG
 		let hgDenom = pow(max(1e-4, 1 + g * g - 2 * g * cosTheta), 1.5)
@@ -125,19 +130,23 @@ struct SkyModel {
 	}
 
 	/// Tone-mapped, gamma-encoded sky colour for a view direction.
-	func color(sunAltitudeDeg: Double, viewElevationDeg: Double, relativeAzimuthDeg: Double) -> Color {
+	func color(sunAltitudeDeg: Double, viewElevationDeg: Double, scatterCosTheta: Double) -> Color {
 		tonemap(radiance(sunAltitudeDeg: sunAltitudeDeg,
 		                 viewElevationDeg: viewElevationDeg,
-		                 relativeAzimuthDeg: relativeAzimuthDeg))
+		                 scatterCosTheta: scatterCosTheta))
 	}
 
 	// MARK: Mesh
 
 	/// Builds the sky as a `MeshGradient`, plus the vertical colour ramp used by `SkyGradient.stops`.
+	///
+	/// The warm sun glow is centred on `sunAnchor` so it can be aligned with the sun marker each chart
+	/// draws. A vertex's scattering angle grows with its normalised distance from the anchor, so the
+	/// forward-Mie glow peaks exactly at the anchor and falls off around it.
 	/// - Parameters:
 	///   - sunAltitudeDeg: Sun altitude above the horizon, in degrees.
-	///   - sunX: Sun's horizontal position as a fraction of the day (0…1), matching the daylight chart.
-	func mesh(sunAltitudeDeg: Double, sunX: Double) -> (gradient: MeshGradient, stops: [Color]) {
+	///   - sunAnchor: The sun's position in the gradient's own bounds (0…1, y-down).
+	func mesh(sunAltitudeDeg: Double, sunAnchor: UnitPoint) -> (gradient: MeshGradient, stops: [Color]) {
 		let w = meshWidth, h = meshHeight
 
 		var points = [SIMD2<Float>]()
@@ -152,11 +161,12 @@ struct SkyModel {
 			let elevation = maxElevationDeg * elevationFraction * elevationFraction
 			for col in 0 ..< w {
 				let colX = Double(col) / Double(w - 1)
-				let relativeAzimuth = (colX - sunX) * azimuthSpanDeg
+				let distance = hypot(colX - Double(sunAnchor.x), rowY - Double(sunAnchor.y))
+				let scatterAngle = distance * glowAngularScaleDeg * .pi / 180
 				// Below the horizon the physical sky darkens to black — no artificial night floor.
 				let vertexColor = color(sunAltitudeDeg: sunAltitudeDeg,
 				                        viewElevationDeg: elevation,
-				                        relativeAzimuthDeg: relativeAzimuth)
+				                        scatterCosTheta: cos(scatterAngle))
 				points.append(SIMD2<Float>(Float(colX), Float(rowY)))
 				colors.append(vertexColor)
 			}
@@ -166,7 +176,7 @@ struct SkyModel {
 		                            smoothsColors: true, colorSpace: .perceptual)
 
 		// Vertical ramp of the column farthest from the sun (first = zenith, last = horizon).
-		let farColumn = sunX < 0.5 ? w - 1 : 0
+		let farColumn = sunAnchor.x < 0.5 ? w - 1 : 0
 		let stops = (0 ..< h).map { colors[$0 * w + farColumn] }
 
 		return (gradient, stops)
@@ -218,9 +228,17 @@ struct SkyModel {
 // MARK: - SkyGradient
 
 struct SkyGradient: View, ShapeStyle {
+	/// Named coordinate space shared between a chart and its `SkyGradient` background so the sun
+	/// marker's position can be reported via `SkySunAnchorPreferenceKey` and normalised consistently.
+	static let coordinateSpaceName = "skyGradient"
+
 	@Environment(\.timeZone) var timeZone
 
 	var ntSolar: NTSolar? = nil
+
+	/// Where the sun sits in this gradient's own bounds (0…1, y-down). Callers with chart geometry
+	/// supply the sun marker's position; when `nil` the glow falls back to a time + altitude default.
+	var sunAnchor: UnitPoint? = nil
 
 	private var effectiveSolar: NTSolar? {
 		if let ntSolar {
@@ -233,11 +251,18 @@ struct SkyGradient: View, ShapeStyle {
 		let solar = effectiveSolar
 		let date = solar?.date ?? .now
 		let sunAltitude = solar?.altitude(at: date) ?? 0
-		let sunX: Double = {
+		return SkyModel.standard.mesh(sunAltitudeDeg: sunAltitude, sunAnchor: sunAnchor ?? defaultAnchor(for: solar, at: date, altitude: sunAltitude))
+	}
+
+	/// A sensible glow position for surfaces with no chart geometry: horizontally at the sun's
+	/// time of day, vertically higher as the sun climbs.
+	private func defaultAnchor(for solar: NTSolar?, at date: Date, altitude: Double) -> UnitPoint {
+		let x: Double = {
 			guard let solar else { return 0.5 }
 			return min(max(date.timeIntervalSince(solar.startOfDay) / .twentyFourHours, 0), 1)
 		}()
-		return SkyModel.standard.mesh(sunAltitudeDeg: sunAltitude, sunX: sunX)
+		let y = 1 - min(max(altitude / SkyModel.standard.maxElevationDeg, 0), 1)
+		return UnitPoint(x: x, y: y)
 	}
 
 	/// The vertical colour ramp; `first` is the sky/zenith, `last` the horizon.
@@ -306,7 +331,7 @@ private struct AltitudeSweepPreview: View {
 		VStack(spacing: 0) {
 			ForEach(Array(altitudes), id: \.self) { altitude in
 				ZStack {
-					SkyModel.standard.mesh(sunAltitudeDeg: altitude, sunX: 0.5).gradient
+					SkyModel.standard.mesh(sunAltitudeDeg: altitude, sunAnchor: .center).gradient
 					Text("\(Int(altitude))°")
 						.font(.headline.monospacedDigit())
 						.foregroundStyle(.white)
@@ -317,21 +342,24 @@ private struct AltitudeSweepPreview: View {
 	}
 }
 
-/// Interactive tuning surface for the model's sun altitude and horizontal position.
+/// Interactive tuning surface for the model's sun altitude and the 2-D glow anchor.
 private struct SkyModelSliderPreview: View {
 	@State private var altitude = 8.0
-	@State private var sunX = 0.5
+	@State private var anchorX = 0.5
+	@State private var anchorY = 0.5
 
 	var body: some View {
 		VStack {
-			SkyModel.standard.mesh(sunAltitudeDeg: altitude, sunX: sunX).gradient
+			SkyModel.standard.mesh(sunAltitudeDeg: altitude, sunAnchor: UnitPoint(x: anchorX, y: anchorY)).gradient
 				.ignoresSafeArea()
 				.overlay(alignment: .bottom) {
 					VStack(alignment: .leading) {
 						Text("Altitude \(altitude, format: .number.precision(.fractionLength(1)))°")
 						Slider(value: $altitude, in: -20 ... 90)
-						Text("Sun X \(sunX, format: .number.precision(.fractionLength(2)))")
-						Slider(value: $sunX, in: 0 ... 1)
+						Text("Anchor X \(anchorX, format: .number.precision(.fractionLength(2)))")
+						Slider(value: $anchorX, in: 0 ... 1)
+						Text("Anchor Y \(anchorY, format: .number.precision(.fractionLength(2)))")
+						Slider(value: $anchorY, in: 0 ... 1)
 					}
 					.padding()
 					.background(.thinMaterial, in: .rect(cornerRadius: 12))

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -42,9 +42,6 @@ struct SkyModel {
 	/// Multiplier applied before tone-mapping. The main lever for overall brightness.
 	var exposure = 3.0
 
-	/// Deep-blue night colours [zenith, horizon] the physical sky blends down to for legibility.
-	var nightFloor = SkyGradient.night
-
 	var viewSamples = 16
 	var lightSamples = 8
 
@@ -142,7 +139,6 @@ struct SkyModel {
 	///   - sunX: Sun's horizontal position as a fraction of the day (0…1), matching the daylight chart.
 	func mesh(sunAltitudeDeg: Double, sunX: Double) -> (gradient: MeshGradient, stops: [Color]) {
 		let w = meshWidth, h = meshHeight
-		let blend = nightBlend(sunAltitudeDeg: sunAltitudeDeg)
 
 		var points = [SIMD2<Float>]()
 		var colors = [Color]()
@@ -157,12 +153,12 @@ struct SkyModel {
 			for col in 0 ..< w {
 				let colX = Double(col) / Double(w - 1)
 				let relativeAzimuth = (colX - sunX) * azimuthSpanDeg
-				let physical = color(sunAltitudeDeg: sunAltitudeDeg,
-				                     viewElevationDeg: elevation,
-				                     relativeAzimuthDeg: relativeAzimuth)
-				let blended = physical.mix(with: floorColor(elevationFraction: elevationFraction), by: CGFloat(blend))
+				// Below the horizon the physical sky darkens to black — no artificial night floor.
+				let vertexColor = color(sunAltitudeDeg: sunAltitudeDeg,
+				                        viewElevationDeg: elevation,
+				                        relativeAzimuthDeg: relativeAzimuth)
 				points.append(SIMD2<Float>(Float(colX), Float(rowY)))
-				colors.append(blended)
+				colors.append(vertexColor)
 			}
 		}
 
@@ -183,34 +179,19 @@ struct SkyModel {
 		max(0, 1 - abs(height - 25000) / 15000)
 	}
 
-	/// How much the physical sky has faded to the night floor (0 = physical, 1 = floor).
-	/// Fades in across civil-to-astronomical twilight.
-	private func nightBlend(sunAltitudeDeg: Double) -> Double {
-		1 - smoothstep(-18, -6, sunAltitudeDeg)
-	}
-
-	private func floorColor(elevationFraction: Double) -> Color {
-		guard nightFloor.count >= 2 else { return nightFloor.first ?? .black }
-		return nightFloor[1].mix(with: nightFloor[0], by: CGFloat(elevationFraction))
-	}
-
+	/// Luminance-based Reinhard: compresses brightness while preserving chroma, so the daytime
+	/// sky stays saturated blue instead of desaturating toward grey the way per-channel Reinhard does.
 	private func tonemap(_ radiance: SIMD3<Double>) -> Color {
-		func channel(_ value: Double) -> Double {
-			let exposed = value * exposure
-			let mapped = exposed / (1 + exposed) // Reinhard
-			return encodeSRGB(mapped)
-		}
-		return Color(.sRGB, red: channel(radiance.x), green: channel(radiance.y), blue: channel(radiance.z))
+		let exposed = radiance * exposure
+		let luminance = 0.2126 * exposed.x + 0.7152 * exposed.y + 0.0722 * exposed.z
+		let scale = luminance > 0 ? 1 / (1 + luminance) : 0
+		let mapped = exposed * scale
+		return Color(.sRGB, red: encodeSRGB(mapped.x), green: encodeSRGB(mapped.y), blue: encodeSRGB(mapped.z))
 	}
 
 	private func encodeSRGB(_ value: Double) -> Double {
 		let c = min(max(value, 0), 1)
 		return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1 / 2.4) - 0.055
-	}
-
-	private func smoothstep(_ edge0: Double, _ edge1: Double, _ x: Double) -> Double {
-		let t = min(max((x - edge0) / (edge1 - edge0), 0), 1)
-		return t * t * (3 - 2 * t)
 	}
 
 	/// Far intersection distance of a ray with a sphere centred at the origin, if any.
@@ -247,12 +228,6 @@ struct SkyGradient: View, ShapeStyle {
 		}
 		return NTSolar(for: .now, coordinate: .proxiedToTimeZone, timeZone: timeZone)
 	}
-
-	/// Deep-blue night floor [zenith, horizon]. The physical sky settles onto these for legibility.
-	static let night = [
-		Color(red: 0.007, green: 0.03, blue: 0.17),
-		Color(red: 0.234, green: 0.446, blue: 0.58),
-	]
 
 	private var skyMesh: (gradient: MeshGradient, stops: [Color]) {
 		let solar = effectiveSolar

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -662,9 +662,10 @@ struct SkyView: View {
 					               startRadius: 0,
 					               endRadius: max(geo.size.width, geo.size.height))
 						// At sunrise/sunset the aureole stretches along the horizon rather than
-						// staying circular — but only on surfaces that *have* a horizon; the dial's
-						// day wedge and ambient skies keep the round glow.
-						.scaleEffect(x: horizonFraction == nil ? 1 : SkyModel.standard.glowStretch(sunAltitudeDeg: sunAltitudeDeg),
+						// staying circular. The dial's day wedge gets the same treatment: its sun
+						// sits near the dial's left/right edge at those times, where the wedge
+						// boundary runs close to horizontal too.
+						.scaleEffect(x: SkyModel.standard.glowStretch(sunAltitudeDeg: sunAltitudeDeg),
 						             anchor: sunAnchor)
 				}
 				.mask { glowMask }

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -89,7 +89,16 @@ struct SkyModel {
 	/// arcs keep their transmittance-driven colour without showing the sun's aureole itself.
 	var dialScatterCosTheta = 0.5
 
-	static let standard = SkyModel()
+	static let standard: SkyModel = {
+		var model = SkyModel()
+		#if os(watchOS)
+			// The dial ring proved the coarse march indistinguishable after tone-mapping
+			// (see `dialStops`); watch-class CPUs get the same discount everywhere.
+			model.viewSamples = 8
+			model.lightSamples = 4
+		#endif
+		return model
+	}()
 
 	// MARK: Radiance
 
@@ -378,6 +387,93 @@ struct SkyModel {
 	}
 }
 
+// MARK: - Render memoization
+
+/// Sky rendering is pure but not free — each mesh is dozens of ray marches — and SwiftUI
+/// re-evaluates the consuming bodies every frame during scrubbing, time travel, and list
+/// scrolling while the inputs barely move. Memoizing keeps unchanged frames at the cost of a
+/// dictionary lookup. Lock-guarded rather than actor-isolated because bodies aren't guaranteed
+/// a single thread across targets.
+final class SkyRenderCache<Key: Hashable, Value>: @unchecked Sendable {
+	private var store = [Key: Value]()
+	private let lock = NSLock()
+	private let capacity: Int
+
+	init(capacity: Int) {
+		self.capacity = capacity
+	}
+
+	func value(for key: Key, compute: () -> Value) -> Value {
+		lock.lock()
+		if let cached = store[key] {
+			lock.unlock()
+			return cached
+		}
+		lock.unlock()
+
+		// Computed outside the lock: a rare duplicate computation beats serialising renders.
+		let value = compute()
+
+		lock.lock()
+		if store.count >= capacity {
+			store.removeAll(keepingCapacity: true)
+		}
+		store[key] = value
+		lock.unlock()
+		return value
+	}
+}
+
+private struct SkyMeshKey: Hashable {
+	let altitude: Int
+	let anchorX: Int?
+	let anchorY: Int?
+	let horizon: Int?
+}
+
+private let meshCache = SkyRenderCache<SkyMeshKey, (gradient: MeshGradient, stops: [Color])>(capacity: 64)
+
+private struct SkyDialKey: Hashable {
+	let startOfDay: Date
+	let latitude: Int
+	let longitude: Int
+}
+
+private let dialCache = SkyRenderCache<SkyDialKey, [Gradient.Stop]>(capacity: 16)
+
+extension SkyModel {
+	/// Memoized `mesh`. Inputs quantise below what the soft mesh can show — 0.1° of sun altitude,
+	/// 1/128 of the view for the glow anchor, 1/256 for the horizon — and the mesh renders from
+	/// the quantised values, so hits and misses agree exactly.
+	func cachedMesh(sunAltitudeDeg: Double, sunAnchor: UnitPoint?, horizonFraction: Double?) -> (gradient: MeshGradient, stops: [Color]) {
+		let key = SkyMeshKey(altitude: Int((sunAltitudeDeg * 10).rounded()),
+		                     anchorX: sunAnchor.map { Int(($0.x * 128).rounded()) },
+		                     anchorY: sunAnchor.map { Int(($0.y * 128).rounded()) },
+		                     horizon: horizonFraction.map { Int(($0 * 256).rounded()) })
+		return meshCache.value(for: key) {
+			let anchor: UnitPoint? = if let x = key.anchorX, let y = key.anchorY {
+				UnitPoint(x: Double(x) / 128, y: Double(y) / 128)
+			} else {
+				nil
+			}
+			return mesh(sunAltitudeDeg: Double(key.altitude) / 10,
+			            sunAnchor: anchor,
+			            horizonFraction: key.horizon.map { Double($0) / 256 })
+		}
+	}
+
+	/// Memoized `dialStops`: the ring depends only on the day and place, but the dial re-evaluates
+	/// its body every frame during time travel.
+	func cachedDialStops(for solar: NTSolar) -> [Gradient.Stop] {
+		let key = SkyDialKey(startOfDay: solar.startOfDay,
+		                     latitude: Int((solar.coordinate.latitude * 1e4).rounded()),
+		                     longitude: Int((solar.coordinate.longitude * 1e4).rounded()))
+		return dialCache.value(for: key) {
+			dialStops(for: solar)
+		}
+	}
+}
+
 // MARK: - SkyGradient
 
 struct SkyGradient: View, ShapeStyle {
@@ -410,9 +506,9 @@ struct SkyGradient: View, ShapeStyle {
 		let solar = effectiveSolar
 		let date = solar?.date ?? .now
 		let sunAltitude = solar?.altitude(at: date) ?? 0
-		return SkyModel.standard.mesh(sunAltitudeDeg: sunAltitude,
-		                              sunAnchor: sunAnchor,
-		                              horizonFraction: horizonFraction)
+		return SkyModel.standard.cachedMesh(sunAltitudeDeg: sunAltitude,
+		                                    sunAnchor: sunAnchor,
+		                                    horizonFraction: horizonFraction)
 	}
 
 	/// The vertical colour ramp; `first` is the sky/zenith, `last` the horizon.

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -62,10 +62,15 @@ struct SkyModel {
 
 	/// Below a horizon there is no sky to march — only ground. The ground band renders as the sky
 	/// just above the horizon reflected darkly, so twilight's warm band carries into it. This is the
-	/// fraction of that light reflected right at the horizon; it fades further with depth.
-	var groundReflectance = 0.3
+	/// fraction of that light reflected right at the horizon (in display-linear space, after
+	/// tone-mapping); it fades further with depth.
+	var groundReflectance = 0.12
 	/// View elevation sampled for the ground's illumination.
 	var groundSourceElevationDeg = 2.5
+
+	/// Sun-relative azimuth assumed on ambient surfaces (no `sunAnchor`): far enough from the sun
+	/// that no bright spot forms anywhere, close enough that sunsets still warm the sky.
+	var ambientSunDeltaAzimuthDeg = 60.0
 
 	/// The dial ring (circular chart) samples the sky at this view elevation…
 	var dialViewElevationDeg = 12.0
@@ -165,11 +170,12 @@ struct SkyModel {
 	/// forward-Mie glow peaks exactly at the anchor and falls off around it.
 	/// - Parameters:
 	///   - sunAltitudeDeg: Sun altitude above the horizon, in degrees.
-	///   - sunAnchor: The sun's position in the gradient's own bounds (0…1, y-down).
+	///   - sunAnchor: The sun's position in the gradient's own bounds (0…1, y-down), or `nil` for
+	///     ambient surfaces, which render elevation-driven colour with no anchored glow.
 	///   - horizonFraction: The horizon line's vertical position in the gradient's bounds (0…1,
-	///     y-down). When set, rows below it render as ground instead of sky, with two rows placed
-	///     tight under the line so the horizon reads as a defined edge across the full width.
-	func mesh(sunAltitudeDeg: Double, sunAnchor: UnitPoint, horizonFraction: Double? = nil) -> (gradient: MeshGradient, stops: [Color]) {
+	///     y-down). When set, rows below it render as ground instead of sky, with a row placed
+	///     tight under the line so the horizon reads as a crisp edge across the full width.
+	func mesh(sunAltitudeDeg: Double, sunAnchor: UnitPoint?, horizonFraction: Double? = nil) -> (gradient: MeshGradient, stops: [Color]) {
 		let rows = rowLayout(horizonFraction: horizonFraction)
 		let w = meshWidth, h = rows.count
 
@@ -179,12 +185,19 @@ struct SkyModel {
 		colors.reserveCapacity(w * h)
 
 		for (rowY, content) in rows {
+			let elevationDeg: Double = switch content {
+			case let .sky(elevationDeg): elevationDeg
+			case .ground: groundSourceElevationDeg
+			}
 			for col in 0 ..< w {
 				let colX = Double(col) / Double(w - 1)
-				let distance = hypot(colX - Double(sunAnchor.x), rowY - Double(sunAnchor.y))
-				let scatterCosTheta = cos(distance * glowAngularScaleDeg * .pi / 180)
+				let scatterCosTheta: Double = if let sunAnchor {
+					cos(hypot(colX - Double(sunAnchor.x), rowY - Double(sunAnchor.y)) * glowAngularScaleDeg * .pi / 180)
+				} else {
+					ambientScatterCosTheta(sunAltitudeDeg: sunAltitudeDeg, viewElevationDeg: elevationDeg)
+				}
 				let vertexColor: Color = switch content {
-				case let .sky(elevationDeg):
+				case .sky:
 					color(sunAltitudeDeg: sunAltitudeDeg,
 					      viewElevationDeg: elevationDeg,
 					      scatterCosTheta: scatterCosTheta)
@@ -202,8 +215,8 @@ struct SkyModel {
 		                            smoothsColors: true, colorSpace: .perceptual)
 
 		// Vertical ramp of the column farthest from the sun (first = zenith, last = horizon/ground).
-		let farColumn = sunAnchor.x < 0.5 ? w - 1 : 0
-		let stops = (0 ..< h).map { colors[$0 * w + farColumn] }
+		let farColumn: Int = (sunAnchor?.x ?? 1) < 0.5 ? w - 1 : 0
+		let stops: [Color] = (0 ..< h).map { row in colors[row * w + farColumn] }
 
 		return (gradient, stops)
 	}
@@ -231,20 +244,34 @@ struct SkyModel {
 			return (y: hf * fraction,
 			        content: .sky(elevationDeg: maxElevationDeg + (minElevationDeg - maxElevationDeg) * fraction))
 		}
-		// A row tight under the horizon gives it a defined edge; the bottom row fades the ground out.
-		rows.append((y: hf + 0.02, content: .ground(reflectance: groundReflectance)))
+		// The first ground row sits almost on top of the last sky row, so the sky→ground transition
+		// spans a fraction of a point and the horizon reads as a crisp edge exactly on the chart's
+		// horizon line; the bottom row fades the ground out.
+		rows.append((y: hf + 0.004, content: .ground(reflectance: groundReflectance)))
 		rows.append((y: 1, content: .ground(reflectance: groundReflectance * 0.4)))
 		return rows
 	}
 
-	/// Ground: the sky just above the horizon, reflected darkly. Twilight's warm horizon band carries
-	/// into it, and the shared ambient floor keeps it no darker than the night sky — so chart content
-	/// drawn over it stays legible.
+	/// Scattering cosine for ambient surfaces: the true angular distance to a sun offset by a fixed
+	/// azimuth, so colour varies with elevation only and the glow never anchors to a point.
+	private func ambientScatterCosTheta(sunAltitudeDeg: Double, viewElevationDeg: Double) -> Double {
+		let sa = sunAltitudeDeg * .pi / 180
+		let ve = viewElevationDeg * .pi / 180
+		let deltaAzimuth = ambientSunDeltaAzimuthDeg * .pi / 180
+		return sin(ve) * sin(sa) + cos(ve) * cos(sa) * cos(deltaAzimuth)
+	}
+
+	/// Ground: the sky just above the horizon, reflected darkly. The reflection happens in
+	/// display-linear space — scene-linear reflectance would be mostly undone by the
+	/// luminance-compressing tone-map, leaving the daytime ground too bright. Twilight's warm band
+	/// still carries into it, and the ambient floor keeps the ground no darker than the night sky,
+	/// so chart content drawn over it stays legible.
 	private func groundColor(sunAltitudeDeg: Double, scatterCosTheta: Double, reflectance: Double) -> Color {
-		let source = radiance(sunAltitudeDeg: sunAltitudeDeg,
-		                      viewElevationDeg: groundSourceElevationDeg,
-		                      scatterCosTheta: scatterCosTheta)
-		return tonemap(source * reflectance + ambientRadiance)
+		let sky = tonemapLinear(radiance(sunAltitudeDeg: sunAltitudeDeg,
+		                                 viewElevationDeg: groundSourceElevationDeg,
+		                                 scatterCosTheta: scatterCosTheta) + ambientRadiance)
+		let nightFloor = ambientRadiance * exposure
+		return encode(sky * reflectance + nightFloor)
 	}
 
 	// MARK: Dial
@@ -284,12 +311,19 @@ struct SkyModel {
 
 	/// Luminance-based Reinhard: compresses brightness while preserving chroma, so the daytime
 	/// sky stays saturated blue instead of desaturating toward grey the way per-channel Reinhard does.
-	private func tonemap(_ radiance: SIMD3<Double>) -> Color {
+	private func tonemapLinear(_ radiance: SIMD3<Double>) -> SIMD3<Double> {
 		let exposed = radiance * exposure
 		let luminance = 0.2126 * exposed.x + 0.7152 * exposed.y + 0.0722 * exposed.z
 		let scale = luminance > 0 ? 1 / (1 + luminance) : 0
-		let mapped = exposed * scale
-		return Color(.sRGB, red: encodeSRGB(mapped.x), green: encodeSRGB(mapped.y), blue: encodeSRGB(mapped.z))
+		return exposed * scale
+	}
+
+	private func tonemap(_ radiance: SIMD3<Double>) -> Color {
+		encode(tonemapLinear(radiance))
+	}
+
+	private func encode(_ mapped: SIMD3<Double>) -> Color {
+		Color(.sRGB, red: encodeSRGB(mapped.x), green: encodeSRGB(mapped.y), blue: encodeSRGB(mapped.z))
 	}
 
 	private func encodeSRGB(_ value: Double) -> Double {
@@ -330,7 +364,8 @@ struct SkyGradient: View, ShapeStyle {
 	var ntSolar: NTSolar? = nil
 
 	/// Where the sun sits in this gradient's own bounds (0…1, y-down). Callers with chart geometry
-	/// supply the sun marker's position; when `nil` the glow falls back to a time + altitude default.
+	/// supply the sun marker's position; when `nil` (ambient surfaces like the watch container
+	/// background or list rows) the sky has no anchored glow at all — only the altitude-driven ramp.
 	var sunAnchor: UnitPoint? = nil
 
 	/// The horizon line's vertical position in this gradient's own bounds (0…1, y-down). When set,
@@ -350,19 +385,8 @@ struct SkyGradient: View, ShapeStyle {
 		let date = solar?.date ?? .now
 		let sunAltitude = solar?.altitude(at: date) ?? 0
 		return SkyModel.standard.mesh(sunAltitudeDeg: sunAltitude,
-		                              sunAnchor: sunAnchor ?? defaultAnchor(for: solar, at: date, altitude: sunAltitude),
+		                              sunAnchor: sunAnchor,
 		                              horizonFraction: horizonFraction)
-	}
-
-	/// A sensible glow position for surfaces with no chart geometry: horizontally at the sun's
-	/// time of day, vertically higher as the sun climbs.
-	private func defaultAnchor(for solar: NTSolar?, at date: Date, altitude: Double) -> UnitPoint {
-		let x: Double = {
-			guard let solar else { return 0.5 }
-			return min(max(date.timeIntervalSince(solar.startOfDay) / .twentyFourHours, 0), 1)
-		}()
-		let y = 1 - min(max(altitude / SkyModel.standard.maxElevationDeg, 0), 1)
-		return UnitPoint(x: x, y: y)
 	}
 
 	/// The vertical colour ramp; `first` is the sky/zenith, `last` the horizon.
@@ -371,7 +395,7 @@ struct SkyGradient: View, ShapeStyle {
 		skyMesh.stops
 	}
 
-	var body: MeshGradient {
+	var body: some View {
 		skyMesh.gradient
 	}
 }
@@ -431,7 +455,7 @@ private struct AltitudeSweepPreview: View {
 		VStack(spacing: 0) {
 			ForEach(Array(altitudes), id: \.self) { altitude in
 				ZStack {
-					SkyModel.standard.mesh(sunAltitudeDeg: altitude, sunAnchor: .center).gradient
+					SkyModel.standard.mesh(sunAltitudeDeg: altitude, sunAnchor: .center, horizonFraction: 0.72).gradient
 					Text(verbatim: "\(Int(altitude))°")
 						.font(.headline.monospacedDigit())
 						.foregroundStyle(.white)

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -55,8 +55,8 @@ struct SkyModel {
 	var viewSamples = 16
 	var lightSamples = 8
 
-	/// Mesh dimensions. A denser grid renders the 2-D sun glow more smoothly.
-	var meshWidth = 9
+	/// Number of vertical samples in the ambient mesh. The mesh only carries the smooth vertical
+	/// ramp — the sun's glow is an analytic radial layer on top — so it stays coarse.
 	var meshHeight = 7
 	/// View elevations sampled at the bottom and top of the rendered strip, in degrees. Keeping the
 	/// bottom above the horizon avoids the muddy long-path haze and gives a calmer, more even ramp.
@@ -71,12 +71,19 @@ struct SkyModel {
 	/// fraction of that light reflected right at the horizon (in display-linear space, after
 	/// tone-mapping); it fades further with depth.
 	var groundReflectance = 0.12
-	/// Extra scattering angle added to ground vertices, pushing the reflected glow out of the tight
-	/// forward-Mie lobe: the ground keeps a hint of warmth under the sun instead of mirroring the
-	/// full aureole below the horizon.
-	var groundGlowAngularOffsetDeg = 30.0
+	/// Fraction of the sun's glow that shows through below the horizon — the ground keeps a hint
+	/// of the aureole rather than mirroring it.
+	var groundGlowTransmission = 0.2
 	/// View elevation sampled for the ground's illumination.
 	var groundSourceElevationDeg = 2.5
+	/// The ground reflects the whole sky dome, not just the horizon band. Blending the (bluer)
+	/// upper sky into the reflection keeps the noon ground a darkened blue instead of a
+	/// desaturated grey, while the horizon sample still carries sunset warmth into the ground.
+	var groundDomeElevationDeg = 45.0
+	var groundDomeWeight = 0.6
+	/// The classic chart's ground band catches ambient daylight beyond its physical sky
+	/// reflection: a light-blue lift while the sun is high, gone by sunset.
+	var belowHorizonDaylightLift = 0.06
 
 	/// Sun-relative azimuth assumed on ambient surfaces (no `sunAnchor`): far enough from the sun
 	/// that no bright spot forms anywhere, close enough that sunsets still warm the sky.
@@ -84,10 +91,17 @@ struct SkyModel {
 
 	/// The dial ring (circular chart) samples the sky at this view elevation…
 	var dialViewElevationDeg = 12.0
-	/// …looking this far from the sun (as a cosine, ~60°). Only the night and twilight arcs of the
-	/// ring stay visible beneath the dynamic day wedge, so this is deliberately wide: the twilight
-	/// arcs keep their transmittance-driven colour without showing the sun's aureole itself.
+	/// …looking this far from the sun (as a cosine, ~60°) while it's up. Only the night and
+	/// twilight arcs of the ring stay visible beneath the dynamic day wedge, so this is
+	/// deliberately wide: the arcs keep transmittance-driven colour without the aureole itself.
 	var dialScatterCosTheta = 0.5
+	/// Pre-tone-map luminance of each below-horizon wedge (civil, nautical, astronomical, night)
+	/// at full daylight. The wedges are stylised — saturated sky-blue steps rather than marched
+	/// twilight, which reads grey — and dim toward `dialNightDimming` as the sun sets.
+	var dialBandLuminances = SIMD4<Double>(0.1, 0.055, 0.03, 0.015)
+	/// Fraction of the wedges' daylight luminance left once the sun has fully set: the Watch solar
+	/// dial's sunset face shows markedly darker wedges than its day face.
+	var dialNightDimming = 0.25
 
 	static let standard: SkyModel = {
 		var model = SkyModel()
@@ -176,7 +190,6 @@ struct SkyModel {
 		// reads as pale blue rather than the yellow-green the extinguished path leaves behind.
 		let tauView = rayleigh * odR + SIMD3<Double>(repeating: mieExt * odM) + ozone * odO
 		let pathOpacity = SIMD3<Double>(1 - exp(-tauView.x), 1 - exp(-tauView.y), 1 - exp(-tauView.z))
-		let skyTint = rayleigh / simd_reduce_max(rayleigh)
 		let inMultiple = multipleScattering * max(0, sin(sa)) * pathOpacity * skyTint
 
 		return (inRayleigh + inMie + inMultiple) * sunIntensity
@@ -192,68 +205,92 @@ struct SkyModel {
 
 	// MARK: Mesh
 
-	/// Builds the sky as a `MeshGradient`, plus the vertical colour ramp used by `SkyGradient.stops`.
-	///
-	/// The warm sun glow is centred on `sunAnchor` so it can be aligned with the sun marker each chart
-	/// draws. A vertex's scattering angle grows with its normalised distance from the anchor, so the
-	/// forward-Mie glow peaks exactly at the anchor and falls off around it.
+	/// Builds the ambient sky — the smooth field the analytic sun glow layers over — as a
+	/// `MeshGradient`, plus the vertical colour ramp used by `SkyGradient.stops`.
 	/// - Parameters:
 	///   - sunAltitudeDeg: Sun altitude above the horizon, in degrees.
-	///   - sunAnchor: The sun's position in the gradient's own bounds (0…1, y-down), or `nil` for
-	///     ambient surfaces, which render elevation-driven colour with no anchored glow.
 	///   - horizonFraction: The horizon line's vertical position in the gradient's bounds (0…1,
 	///     y-down). When set, rows below it render as ground instead of sky, with a row placed
 	///     tight under the line so the horizon reads as a crisp edge across the full width.
-	func mesh(sunAltitudeDeg: Double, sunAnchor: UnitPoint?, horizonFraction: Double? = nil) -> (gradient: MeshGradient, stops: [Color]) {
+	func mesh(sunAltitudeDeg: Double, horizonFraction: Double? = nil) -> (gradient: MeshGradient, stops: [Color]) {
 		let rows = rowLayout(horizonFraction: horizonFraction)
-		let w = meshWidth, h = rows.count
 
+		// The ambient sky has no horizontal variation — the analytic glow layered over it provides
+		// all of it — so two columns suffice, and each row costs one march.
 		var points = [SIMD2<Float>]()
 		var colors = [Color]()
-		points.reserveCapacity(w * h)
-		colors.reserveCapacity(w * h)
+		points.reserveCapacity(rows.count * 2)
+		colors.reserveCapacity(rows.count * 2)
 
 		for (rowY, content) in rows {
 			let elevationDeg: Double = switch content {
 			case let .sky(elevationDeg): elevationDeg
 			case .ground: groundSourceElevationDeg
 			}
-			// Ground vertices widen their scattering angle so the reflected glow falls outside the
-			// tight forward-Mie lobe — only a hint of the aureole survives below the horizon.
-			let groundOffset: Double = switch content {
-			case .sky: 0
-			case .ground: groundGlowAngularOffsetDeg * .pi / 180
+			let scatterCosTheta = ambientScatterCosTheta(sunAltitudeDeg: sunAltitudeDeg, viewElevationDeg: elevationDeg)
+			let rowColor: Color = switch content {
+			case .sky:
+				color(sunAltitudeDeg: sunAltitudeDeg,
+				      viewElevationDeg: elevationDeg,
+				      scatterCosTheta: scatterCosTheta)
+			case let .ground(reflectance):
+				groundColor(sunAltitudeDeg: sunAltitudeDeg,
+				            scatterCosTheta: scatterCosTheta,
+				            reflectance: reflectance)
 			}
-			for col in 0 ..< w {
-				let colX = Double(col) / Double(w - 1)
-				let scatterCosTheta: Double = if let sunAnchor {
-					cos(min(.pi, hypot(colX - Double(sunAnchor.x), rowY - Double(sunAnchor.y)) * glowAngularScaleDeg * .pi / 180 + groundOffset))
-				} else {
-					ambientScatterCosTheta(sunAltitudeDeg: sunAltitudeDeg, viewElevationDeg: elevationDeg)
-				}
-				let vertexColor: Color = switch content {
-				case .sky:
-					color(sunAltitudeDeg: sunAltitudeDeg,
-					      viewElevationDeg: elevationDeg,
-					      scatterCosTheta: scatterCosTheta)
-				case let .ground(reflectance):
-					groundColor(sunAltitudeDeg: sunAltitudeDeg,
-					            scatterCosTheta: scatterCosTheta,
-					            reflectance: reflectance)
-				}
-				points.append(SIMD2<Float>(Float(colX), Float(rowY)))
-				colors.append(vertexColor)
-			}
+			points.append(SIMD2<Float>(0, Float(rowY)))
+			points.append(SIMD2<Float>(1, Float(rowY)))
+			colors.append(rowColor)
+			colors.append(rowColor)
 		}
 
-		let gradient = MeshGradient(width: w, height: h, points: points, colors: colors,
+		let gradient = MeshGradient(width: 2, height: rows.count, points: points, colors: colors,
 		                            smoothsColors: true, colorSpace: .perceptual)
 
-		// Vertical ramp of the column farthest from the sun (first = zenith, last = horizon/ground).
-		let farColumn: Int = (sunAnchor?.x ?? 1) < 0.5 ? w - 1 : 0
-		let stops: [Color] = (0 ..< h).map { row in colors[row * w + farColumn] }
+		// Vertical ramp (first = zenith, last = horizon/ground).
+		let stops: [Color] = (0 ..< rows.count).map { row in colors[row * 2] }
 
 		return (gradient, stops)
+	}
+
+	/// The sun's aureole as an analytic radial gradient: the colour at unit radius `r` is the sky
+	/// looking `r · glowAngularScaleDeg` away from the sun, *minus* the ambient base the glow is
+	/// layered over with `.plusLighter` — so mesh + glow ≈ the fully sun-anchored sky, but with
+	/// per-pixel smoothness and a continuously movable centre.
+	func glowStops(sunAltitudeDeg: Double, stopCount: Int = 12) -> [Gradient.Stop] {
+		// Coarser march, like the dial: the glow is the difference of two similar skies, so fine
+		// sampling washes out of the result anyway.
+		var coarse = self
+		coarse.viewSamples = 8
+		coarse.lightSamples = 4
+
+		let elevationDeg = max(sunAltitudeDeg, groundSourceElevationDeg)
+
+		func encoded(scatterCosTheta: Double) -> SIMD3<Double> {
+			let mapped = coarse.tonemapLinear(coarse.radiance(sunAltitudeDeg: sunAltitudeDeg,
+			                                                  viewElevationDeg: elevationDeg,
+			                                                  scatterCosTheta: scatterCosTheta)
+					+ ambientRadiance)
+			return SIMD3<Double>(encodeSRGB(mapped.x), encodeSRGB(mapped.y), encodeSRGB(mapped.z))
+		}
+
+		let base = encoded(scatterCosTheta: ambientScatterCosTheta(sunAltitudeDeg: sunAltitudeDeg,
+		                                                           viewElevationDeg: elevationDeg))
+		return (0 ..< stopCount).map { i in
+			// Quadratic spacing clusters stops in the tight forward lobe near the centre.
+			let t = Double(i) / Double(stopCount - 1)
+			let location = t * t
+			let angle = location * glowAngularScaleDeg * .pi / 180
+			// `.plusLighter` adds in the display's gamma-encoded space, so each stop is the
+			// gamma-space difference against the ambient base: base + glow reconstructs the
+			// sun-facing sky exactly where they meet.
+			let lit = encoded(scatterCosTheta: cos(min(.pi, angle)))
+			return Gradient.Stop(color: Color(.sRGB,
+			                                  red: max(0, lit.x - base.x),
+			                                  green: max(0, lit.y - base.y),
+			                                  blue: max(0, lit.z - base.z)),
+			                     location: location)
+		}
 	}
 
 	private enum RowContent {
@@ -302,18 +339,38 @@ struct SkyModel {
 	/// still carries into it, and the ambient floor keeps the ground no darker than the night sky,
 	/// so chart content drawn over it stays legible.
 	private func groundColor(sunAltitudeDeg: Double, scatterCosTheta: Double, reflectance: Double) -> Color {
-		let sky = tonemapLinear(radiance(sunAltitudeDeg: sunAltitudeDeg,
-		                                 viewElevationDeg: groundSourceElevationDeg,
-		                                 scatterCosTheta: scatterCosTheta) + ambientRadiance)
+		let horizonBand = radiance(sunAltitudeDeg: sunAltitudeDeg,
+		                           viewElevationDeg: groundSourceElevationDeg,
+		                           scatterCosTheta: scatterCosTheta)
+		let upperDome = radiance(sunAltitudeDeg: sunAltitudeDeg,
+		                         viewElevationDeg: groundDomeElevationDeg,
+		                         scatterCosTheta: scatterCosTheta)
+		let reflected = horizonBand + (upperDome - horizonBand) * groundDomeWeight
+		let sky = tonemapLinear(reflected + ambientRadiance)
 		let nightFloor = ambientRadiance * exposure
-		return encode(sky * reflectance + nightFloor)
+		// Ambient daylight still reaches below the horizon: lift toward light blue while the sun
+		// is high, settling back to the navy floor as it sets.
+		let daylight = skyTint * (belowHorizonDaylightLift * daylightFactor(sunAltitudeDeg: sunAltitudeDeg))
+		return encode(sky * reflectance + nightFloor + daylight)
+	}
+
+	/// Normalised colour of the scattering medium — the hue of generic blue skylight.
+	private var skyTint: SIMD3<Double> {
+		rayleigh / simd_reduce_max(rayleigh)
+	}
+
+	/// How much ambient daylight reaches below-horizon regions: none once the sun touches the
+	/// horizon, full strength by 30° up.
+	private func daylightFactor(sunAltitudeDeg: Double) -> Double {
+		min(max(sunAltitudeDeg / 30, 0), 1)
 	}
 
 	// MARK: Dial
 
-	/// Sky colours around a 24-hour dial, for circular charts: each angle is coloured by the sky at
-	/// that time of day, so day, each twilight band, and night appear as arcs in their true positions.
-	/// Stop locations are fractions of a day from midnight; align them using the chart's midnight angle.
+	/// Sky colours around a 24-hour dial, for circular charts. The daytime arc is a smooth sweep of
+	/// the sky at each time; below the horizon, each twilight band renders as one solid wedge that
+	/// steps darker toward night — the Watch solar dial look. Stop locations are fractions of a day
+	/// from midnight; align them using the chart's midnight angle.
 	func dialStops(for solar: NTSolar, sampleCount: Int = 48) -> [Gradient.Stop] {
 		// Coarser march than the mesh: the dial evaluates many directions, and colour varies smoothly
 		// enough with altitude that the difference is invisible after tone-mapping.
@@ -321,15 +378,63 @@ struct SkyModel {
 		coarse.viewSamples = 8
 		coarse.lightSamples = 4
 
+		// The wedges brighten with the daylight at the *current* moment, not the wedge's own time.
+		let daylight = daylightFactor(sunAltitudeDeg: solar.altitude(at: solar.date))
+
+		/// Colour for one dial angle; depends only on the sun's altitude at that time.
+		func stopColor(altitudeDeg: Double) -> Color {
+			// Below the horizon the ring is stylised: solid, saturated sky-blue wedges stepping
+			// darker toward night, lifted by the current daylight. Marched twilight reads grey
+			// here (its reddened transmittance desaturates the blues), so the wedges don't use it.
+			let bandLuminance: Double = switch altitudeDeg {
+			case (-6)...: dialBandLuminances.x // civil twilight
+			case (-12)...: dialBandLuminances.y // nautical twilight
+			case (-18)...: dialBandLuminances.z // astronomical twilight
+			default: dialBandLuminances.w // night
+			}
+			let wedge = skyTint * (bandLuminance * (dialNightDimming + (1 - dialNightDimming) * daylight))
+
+			// Blend from wedge to real sky across the first few degrees *above* the horizon —
+			// an arc hidden under the dynamic day wedge, so no seam is visible.
+			let sunUpFraction = min(max(altitudeDeg / 4, 0), 1)
+			let sky = sunUpFraction > 0
+				? coarse.radiance(sunAltitudeDeg: altitudeDeg,
+				                  viewElevationDeg: dialViewElevationDeg,
+				                  scatterCosTheta: dialScatterCosTheta)
+				: .zero
+			let blended = wedge + (sky - wedge) * sunUpFraction
+			return coarse.tonemap(blended + coarse.ambientRadiance)
+		}
+
 		let start = solar.startOfDay
 		var stops = (0 ..< sampleCount).map { i in
 			let fraction = Double(i) / Double(sampleCount)
 			let date = start.addingTimeInterval(fraction * .twentyFourHours)
-			let color = coarse.color(sunAltitudeDeg: solar.altitude(at: date),
-			                         viewElevationDeg: dialViewElevationDeg,
-			                         scatterCosTheta: dialScatterCosTheta)
-			return Gradient.Stop(color: color, location: fraction)
+			return Gradient.Stop(color: stopColor(altitudeDeg: solar.altitude(at: date)), location: fraction)
 		}
+
+		// Crisp wedge edges: a pair of near-coincident stops at each twilight boundary, coloured
+		// for the band on each side. Which side is the darker band depends on whether the sun is
+		// rising or setting there.
+		let boundaries: [(date: Date?, thresholdDeg: Double)] = [
+			(solar.sunrise, 0), (solar.sunset, 0),
+			(solar.civilSunrise, -6), (solar.civilSunset, -6),
+			(solar.nauticalSunrise, -12), (solar.nauticalSunset, -12),
+			(solar.astronomicalSunrise, -18), (solar.astronomicalSunset, -18),
+		]
+		for (date, thresholdDeg) in boundaries {
+			guard let date else { continue }
+			let fraction = date.timeIntervalSince(start) / .twentyFourHours
+			guard fraction > 0, fraction < 1 else { continue }
+			let rising = solar.altitude(at: date.addingTimeInterval(600)) > solar.altitude(at: date.addingTimeInterval(-600))
+			let earlier = stopColor(altitudeDeg: thresholdDeg + (rising ? -0.5 : 0.5))
+			let later = stopColor(altitudeDeg: thresholdDeg + (rising ? 0.5 : -0.5))
+			stops.append(Gradient.Stop(color: earlier, location: fraction - 0.0001))
+			stops.append(Gradient.Stop(color: later, location: fraction + 0.0001))
+		}
+
+		stops.sort { $0.location < $1.location }
+
 		// Close the ring seamlessly.
 		if let first = stops.first {
 			stops.append(Gradient.Stop(color: first.color, location: 1))
@@ -403,7 +508,16 @@ final class SkyRenderCache<Key: Hashable, Value>: @unchecked Sendable {
 		self.capacity = capacity
 	}
 
+	/// Xcode Previews hot-swap code into a persistent host process, so memoized colours would
+	/// outlive edits to the model's constants and show stale skies while tuning. Previews render
+	/// uncached instead.
+	private static var isRunningForPreviews: Bool {
+		ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+	}
+
 	func value(for key: Key, compute: () -> Value) -> Value {
+		guard !Self.isRunningForPreviews else { return compute() }
+
 		lock.lock()
 		if let cached = store[key] {
 			lock.unlock()
@@ -426,50 +540,102 @@ final class SkyRenderCache<Key: Hashable, Value>: @unchecked Sendable {
 
 private struct SkyMeshKey: Hashable {
 	let altitude: Int
-	let anchorX: Int?
-	let anchorY: Int?
 	let horizon: Int?
 }
 
 private let meshCache = SkyRenderCache<SkyMeshKey, (gradient: MeshGradient, stops: [Color])>(capacity: 64)
+private let glowCache = SkyRenderCache<Int, [Gradient.Stop]>(capacity: 64)
 
 private struct SkyDialKey: Hashable {
 	let startOfDay: Date
 	let latitude: Int
 	let longitude: Int
+	/// The wedges lift with the current daylight, so the ring varies with the sun's altitude too
+	/// (quantised to 0.5°).
+	let altitude: Int
 }
 
-private let dialCache = SkyRenderCache<SkyDialKey, [Gradient.Stop]>(capacity: 16)
+private let dialCache = SkyRenderCache<SkyDialKey, [Gradient.Stop]>(capacity: 64)
 
 extension SkyModel {
-	/// Memoized `mesh`. Inputs quantise below what the soft mesh can show — 0.1° of sun altitude,
-	/// 1/128 of the view for the glow anchor, 1/256 for the horizon — and the mesh renders from
-	/// the quantised values, so hits and misses agree exactly.
-	func cachedMesh(sunAltitudeDeg: Double, sunAnchor: UnitPoint?, horizonFraction: Double?) -> (gradient: MeshGradient, stops: [Color]) {
+	/// Memoized `mesh`. Inputs quantise below perception — 0.1° of sun altitude, 1/256 of the view
+	/// for the horizon — and the mesh renders from the quantised values, so hits and misses agree
+	/// exactly. The glow anchor isn't an input at all: during a scrub the base sky is a permanent
+	/// cache hit while only the analytic glow layer moves.
+	func cachedMesh(sunAltitudeDeg: Double, horizonFraction: Double?) -> (gradient: MeshGradient, stops: [Color]) {
 		let key = SkyMeshKey(altitude: Int((sunAltitudeDeg * 10).rounded()),
-		                     anchorX: sunAnchor.map { Int(($0.x * 128).rounded()) },
-		                     anchorY: sunAnchor.map { Int(($0.y * 128).rounded()) },
 		                     horizon: horizonFraction.map { Int(($0 * 256).rounded()) })
 		return meshCache.value(for: key) {
-			let anchor: UnitPoint? = if let x = key.anchorX, let y = key.anchorY {
-				UnitPoint(x: Double(x) / 128, y: Double(y) / 128)
-			} else {
-				nil
-			}
-			return mesh(sunAltitudeDeg: Double(key.altitude) / 10,
-			            sunAnchor: anchor,
-			            horizonFraction: key.horizon.map { Double($0) / 256 })
+			mesh(sunAltitudeDeg: Double(key.altitude) / 10,
+			     horizonFraction: key.horizon.map { Double($0) / 256 })
 		}
 	}
 
-	/// Memoized `dialStops`: the ring depends only on the day and place, but the dial re-evaluates
-	/// its body every frame during time travel.
+	/// Memoized `glowStops`, quantised to 0.1° of sun altitude.
+	func cachedGlowStops(sunAltitudeDeg: Double) -> [Gradient.Stop] {
+		let key = Int((sunAltitudeDeg * 10).rounded())
+		return glowCache.value(for: key) {
+			glowStops(sunAltitudeDeg: Double(key) / 10)
+		}
+	}
+
+	/// Memoized `dialStops`: the ring depends only on the day, the place, and (coarsely) the
+	/// current sun altitude, but the dial re-evaluates its body every frame during time travel.
 	func cachedDialStops(for solar: NTSolar) -> [Gradient.Stop] {
 		let key = SkyDialKey(startOfDay: solar.startOfDay,
 		                     latitude: Int((solar.coordinate.latitude * 1e4).rounded()),
-		                     longitude: Int((solar.coordinate.longitude * 1e4).rounded()))
+		                     longitude: Int((solar.coordinate.longitude * 1e4).rounded()),
+		                     altitude: Int((solar.altitude(at: solar.date) * 2).rounded()))
 		return dialCache.value(for: key) {
 			dialStops(for: solar)
+		}
+	}
+}
+
+// MARK: - SkyView
+
+/// The composited sky: the coarse ambient mesh with the sun's aureole layered over it as an
+/// analytic radial gradient. The radial layer is rendered per-pixel by the GPU and its centre is
+/// a continuous parameter, so the glow tracks the sun exactly at any frame rate — the mesh only
+/// ever carries the smooth ambient field. `SkyGradient` wraps this with solar bookkeeping; the
+/// tuning previews drive it directly.
+struct SkyView: View {
+	var sunAltitudeDeg: Double
+	var sunAnchor: UnitPoint? = nil
+	var horizonFraction: Double? = nil
+
+	var body: some View {
+		ZStack {
+			SkyModel.standard.cachedMesh(sunAltitudeDeg: sunAltitudeDeg, horizonFraction: horizonFraction).gradient
+
+			if let sunAnchor {
+				GeometryReader { geo in
+					RadialGradient(stops: SkyModel.standard.cachedGlowStops(sunAltitudeDeg: sunAltitudeDeg),
+					               center: sunAnchor,
+					               startRadius: 0,
+					               endRadius: max(geo.size.width, geo.size.height))
+				}
+				.mask { glowMask }
+				// Blend applied last: inside the mask's compositing group there is no backdrop,
+				// and the glow's opaque near-black skirt would paint over the mesh instead of
+				// adding to it.
+				.blendMode(.plusLighter)
+			}
+		}
+		.compositingGroup()
+	}
+
+	/// Only a hint of the aureole survives below the horizon.
+	@ViewBuilder
+	private var glowMask: some View {
+		if let horizonFraction {
+			LinearGradient(stops: [
+				.init(color: .white, location: 0),
+				.init(color: .white, location: horizonFraction),
+				.init(color: .white.opacity(SkyModel.standard.groundGlowTransmission), location: horizonFraction + 0.004),
+			], startPoint: .top, endPoint: .bottom)
+		} else {
+			Color.white
 		}
 	}
 }
@@ -502,23 +668,20 @@ struct SkyGradient: View, ShapeStyle {
 		return NTSolar(for: .now, coordinate: .proxiedToTimeZone, timeZone: timeZone)
 	}
 
-	private var skyMesh: (gradient: MeshGradient, stops: [Color]) {
+	private var sunAltitudeDeg: Double {
 		let solar = effectiveSolar
 		let date = solar?.date ?? .now
-		let sunAltitude = solar?.altitude(at: date) ?? 0
-		return SkyModel.standard.cachedMesh(sunAltitudeDeg: sunAltitude,
-		                                    sunAnchor: sunAnchor,
-		                                    horizonFraction: horizonFraction)
+		return solar?.altitude(at: date) ?? 0
 	}
 
 	/// The vertical colour ramp; `first` is the sky/zenith, `last` the horizon.
 	/// Consumed by `ShareSolarChartView` for the Instagram story background colours.
 	var stops: [Color] {
-		skyMesh.stops
+		SkyModel.standard.cachedMesh(sunAltitudeDeg: sunAltitudeDeg, horizonFraction: horizonFraction).stops
 	}
 
 	var body: some View {
-		skyMesh.gradient
+		SkyView(sunAltitudeDeg: sunAltitudeDeg, sunAnchor: sunAnchor, horizonFraction: horizonFraction)
 	}
 }
 
@@ -577,7 +740,7 @@ private struct AltitudeSweepPreview: View {
 		VStack(spacing: 0) {
 			ForEach(Array(altitudes), id: \.self) { altitude in
 				ZStack {
-					SkyModel.standard.mesh(sunAltitudeDeg: altitude, sunAnchor: .center, horizonFraction: 0.72).gradient
+					SkyView(sunAltitudeDeg: altitude, sunAnchor: .center, horizonFraction: 0.72)
 					Text(verbatim: "\(Int(altitude))°")
 						.font(.headline.monospacedDigit())
 						.foregroundStyle(.white)
@@ -596,7 +759,7 @@ private struct SkyModelSliderPreview: View {
 
 	var body: some View {
 		VStack {
-			SkyModel.standard.mesh(sunAltitudeDeg: altitude, sunAnchor: UnitPoint(x: anchorX, y: anchorY)).gradient
+			SkyView(sunAltitudeDeg: altitude, sunAnchor: UnitPoint(x: anchorX, y: anchorY))
 				.ignoresSafeArea()
 				.overlay(alignment: .bottom) {
 					VStack(alignment: .leading) {

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -7,15 +7,234 @@
 
 import CoreLocation
 import Foundation
+import simd
 import SwiftUI
 
-/*
- Date construction snippet for reference:
+// MARK: - SkyModel
 
- let date = DateComponents(calendar: Calendar(identifier: .gregorian),
-                           timeZone: TimeZone(identifier: "America/New_York"),
-                           year: 2021, month: 12, day: 25, hour: 10, minute: 0).date
- */
+/// A physically-motivated model of daytime sky colour.
+///
+/// Colours are derived from single-scattering atmospheric physics (Nishita-style):
+/// a view ray is marched through a spherical-shell atmosphere, accumulating Rayleigh
+/// (air) and Mie (aerosol) in-scattering with ozone absorption. The Mie forward lobe
+/// produces the warm glow that anchors to the sun's position — the effect seen on the
+/// Apple Watch solar faces — while Rayleigh gives the blue zenith and reddened horizon.
+///
+/// The output feeds a SwiftUI `MeshGradient`, so a single implementation works on every
+/// surface (main app, widgets, watchOS) with no Metal. All constants are stored, so
+/// tuning is a matter of changing `standard`'s values rather than the algorithm.
+struct SkyModel {
+	/// Rayleigh scattering coefficient per RGB wavelength (1/m).
+	var rayleigh = SIMD3<Double>(5.8e-6, 13.5e-6, 33.1e-6)
+	/// Mie scattering coefficient (1/m).
+	var mie = 21e-6
+	/// Henyey–Greenstein asymmetry: how tightly the Mie glow hugs the sun (0…1).
+	var mieG = 0.76
+	/// Ozone absorption per RGB wavelength (1/m) — deepens twilight blues and purples.
+	var ozone = SIMD3<Double>(0.650e-6, 1.881e-6, 0.085e-6)
+
+	var rayleighScaleHeight = 8000.0
+	var mieScaleHeight = 1200.0
+	var planetRadius = 6.36e6
+	var atmosphereRadius = 6.42e6
+
+	var sunIntensity = 22.0
+	/// Multiplier applied before tone-mapping. The main lever for overall brightness.
+	var exposure = 3.0
+
+	/// Deep-blue night colours [zenith, horizon] the physical sky blends down to for legibility.
+	var nightFloor = SkyGradient.night
+
+	var viewSamples = 16
+	var lightSamples = 8
+
+	/// Mesh dimensions. More columns tighten the sun glow; more rows sharpen the horizon band.
+	var meshWidth = 7
+	var meshHeight = 5
+	/// Highest view elevation sampled (top of the rendered strip), in degrees.
+	var maxElevationDeg = 60.0
+	/// Horizontal degrees of azimuth spanned across the full width of the gradient.
+	var azimuthSpanDeg = 180.0
+
+	static let standard = SkyModel()
+
+	// MARK: Radiance
+
+	/// Linear (pre-tone-map) RGB radiance for a view direction, given the sun's altitude.
+	/// - Parameters:
+	///   - sunAltitudeDeg: Sun altitude above the horizon, in degrees (negative below).
+	///   - viewElevationDeg: View elevation above the horizon, in degrees.
+	///   - relativeAzimuthDeg: View azimuth relative to the sun, in degrees (0 = toward the sun).
+	func radiance(sunAltitudeDeg: Double, viewElevationDeg: Double, relativeAzimuthDeg: Double) -> SIMD3<Double> {
+		let sa = sunAltitudeDeg * .pi / 180
+		let ve = viewElevationDeg * .pi / 180
+		let raz = relativeAzimuthDeg * .pi / 180
+
+		// Sun's horizontal azimuth is +x, up is +y.
+		let sun = SIMD3<Double>(cos(sa), sin(sa), 0)
+		let view = SIMD3<Double>(cos(ve) * cos(raz), sin(ve), cos(ve) * sin(raz))
+		let origin = SIMD3<Double>(0, planetRadius, 0)
+
+		guard let tMax = raySphereFar(origin, view, atmosphereRadius) else { return .zero }
+
+		let cosTheta = simd_dot(view, sun)
+		let phaseR = 3.0 / (16.0 * .pi) * (1 + cosTheta * cosTheta)
+		let g = mieG
+		let hgDenom = pow(max(1e-4, 1 + g * g - 2 * g * cosTheta), 1.5)
+		let phaseM = (1 - g * g) / (4 * .pi * hgDenom)
+
+		let mieExt = mie * 1.11 // aerosols absorb a little as well as scatter
+
+		let seg = tMax / Double(viewSamples)
+		var sumR = SIMD3<Double>.zero
+		var sumM = SIMD3<Double>.zero
+		var odR = 0.0, odM = 0.0, odO = 0.0 // optical depth accumulated along the view ray
+
+		for i in 0 ..< viewSamples {
+			let t = (Double(i) + 0.5) * seg
+			let p = origin + view * t
+			let h = max(0, simd_length(p) - planetRadius)
+
+			let dR = exp(-h / rayleighScaleHeight) * seg
+			let dM = exp(-h / mieScaleHeight) * seg
+			let dO = ozoneDensity(h) * seg
+			odR += dR; odM += dM; odO += dO
+
+			// Skip samples the sun can't reach (below the local horizon = in planet shadow).
+			guard !hitsPlanet(p, sun), let tLight = raySphereFar(p, sun, atmosphereRadius) else { continue }
+
+			let lSeg = tLight / Double(lightSamples)
+			var lodR = 0.0, lodM = 0.0, lodO = 0.0
+			for j in 0 ..< lightSamples {
+				let pl = p + sun * ((Double(j) + 0.5) * lSeg)
+				let hl = max(0, simd_length(pl) - planetRadius)
+				lodR += exp(-hl / rayleighScaleHeight) * lSeg
+				lodM += exp(-hl / mieScaleHeight) * lSeg
+				lodO += ozoneDensity(hl) * lSeg
+			}
+
+			let tau = rayleigh * (odR + lodR)
+				+ SIMD3<Double>(repeating: mieExt * (odM + lodM))
+				+ ozone * (odO + lodO)
+			let transmittance = SIMD3<Double>(exp(-tau.x), exp(-tau.y), exp(-tau.z))
+
+			sumR += transmittance * dR
+			sumM += transmittance * dM
+		}
+
+		let inRayleigh = rayleigh * sumR * phaseR
+		let inMie = sumM * (mie * phaseM)
+		return (inRayleigh + inMie) * sunIntensity
+	}
+
+	/// Tone-mapped, gamma-encoded sky colour for a view direction.
+	func color(sunAltitudeDeg: Double, viewElevationDeg: Double, relativeAzimuthDeg: Double) -> Color {
+		tonemap(radiance(sunAltitudeDeg: sunAltitudeDeg,
+		                 viewElevationDeg: viewElevationDeg,
+		                 relativeAzimuthDeg: relativeAzimuthDeg))
+	}
+
+	// MARK: Mesh
+
+	/// Builds the sky as a `MeshGradient`, plus the vertical colour ramp used by `SkyGradient.stops`.
+	/// - Parameters:
+	///   - sunAltitudeDeg: Sun altitude above the horizon, in degrees.
+	///   - sunX: Sun's horizontal position as a fraction of the day (0…1), matching the daylight chart.
+	func mesh(sunAltitudeDeg: Double, sunX: Double) -> (gradient: MeshGradient, stops: [Color]) {
+		let w = meshWidth, h = meshHeight
+		let blend = nightBlend(sunAltitudeDeg: sunAltitudeDeg)
+
+		var points = [SIMD2<Float>]()
+		var colors = [Color]()
+		points.reserveCapacity(w * h)
+		colors.reserveCapacity(w * h)
+
+		for row in 0 ..< h {
+			let rowY = Double(row) / Double(h - 1)
+			let elevationFraction = 1 - rowY
+			// Bias sampling toward the horizon, where colour varies most.
+			let elevation = maxElevationDeg * elevationFraction * elevationFraction
+			for col in 0 ..< w {
+				let colX = Double(col) / Double(w - 1)
+				let relativeAzimuth = (colX - sunX) * azimuthSpanDeg
+				let physical = color(sunAltitudeDeg: sunAltitudeDeg,
+				                     viewElevationDeg: elevation,
+				                     relativeAzimuthDeg: relativeAzimuth)
+				let blended = physical.mix(with: floorColor(elevationFraction: elevationFraction), by: CGFloat(blend))
+				points.append(SIMD2<Float>(Float(colX), Float(rowY)))
+				colors.append(blended)
+			}
+		}
+
+		let gradient = MeshGradient(width: w, height: h, points: points, colors: colors,
+		                            smoothsColors: true, colorSpace: .perceptual)
+
+		// Vertical ramp of the column farthest from the sun (first = zenith, last = horizon).
+		let farColumn = sunX < 0.5 ? w - 1 : 0
+		let stops = (0 ..< h).map { colors[$0 * w + farColumn] }
+
+		return (gradient, stops)
+	}
+
+	// MARK: Helpers
+
+	/// Ozone concentration tent, peaking around 25 km.
+	private func ozoneDensity(_ height: Double) -> Double {
+		max(0, 1 - abs(height - 25000) / 15000)
+	}
+
+	/// How much the physical sky has faded to the night floor (0 = physical, 1 = floor).
+	/// Fades in across civil-to-astronomical twilight.
+	private func nightBlend(sunAltitudeDeg: Double) -> Double {
+		1 - smoothstep(-18, -6, sunAltitudeDeg)
+	}
+
+	private func floorColor(elevationFraction: Double) -> Color {
+		guard nightFloor.count >= 2 else { return nightFloor.first ?? .black }
+		return nightFloor[1].mix(with: nightFloor[0], by: CGFloat(elevationFraction))
+	}
+
+	private func tonemap(_ radiance: SIMD3<Double>) -> Color {
+		func channel(_ value: Double) -> Double {
+			let exposed = value * exposure
+			let mapped = exposed / (1 + exposed) // Reinhard
+			return encodeSRGB(mapped)
+		}
+		return Color(.sRGB, red: channel(radiance.x), green: channel(radiance.y), blue: channel(radiance.z))
+	}
+
+	private func encodeSRGB(_ value: Double) -> Double {
+		let c = min(max(value, 0), 1)
+		return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1 / 2.4) - 0.055
+	}
+
+	private func smoothstep(_ edge0: Double, _ edge1: Double, _ x: Double) -> Double {
+		let t = min(max((x - edge0) / (edge1 - edge0), 0), 1)
+		return t * t * (3 - 2 * t)
+	}
+
+	/// Far intersection distance of a ray with a sphere centred at the origin, if any.
+	private func raySphereFar(_ origin: SIMD3<Double>, _ direction: SIMD3<Double>, _ radius: Double) -> Double? {
+		let b = 2 * simd_dot(origin, direction)
+		let c = simd_dot(origin, origin) - radius * radius
+		let discriminant = b * b - 4 * c
+		guard discriminant >= 0 else { return nil }
+		let t = (-b + sqrt(discriminant)) / 2
+		return t > 0 ? t : nil
+	}
+
+	/// Whether a ray from `origin` toward `direction` enters the planet (i.e. is shadowed).
+	private func hitsPlanet(_ origin: SIMD3<Double>, _ direction: SIMD3<Double>) -> Bool {
+		let b = 2 * simd_dot(origin, direction)
+		let c = simd_dot(origin, origin) - planetRadius * planetRadius
+		let discriminant = b * b - 4 * c
+		guard discriminant >= 0 else { return false }
+		let tNear = (-b - sqrt(discriminant)) / 2
+		return tNear > 0
+	}
+}
+
+// MARK: - SkyGradient
 
 struct SkyGradient: View, ShapeStyle {
 	@Environment(\.timeZone) var timeZone
@@ -29,91 +248,35 @@ struct SkyGradient: View, ShapeStyle {
 		return NTSolar(for: .now, coordinate: .proxiedToTimeZone, timeZone: timeZone)
 	}
 
-	static let dawn = [
-		Color(red: 0.388, green: 0.435, blue: 0.643),
-		Color(red: 0.91, green: 0.796, blue: 0.753),
-	]
-
-	static let morning = [
-		Color(red: 0.11, green: 0.573, blue: 0.824),
-		Color(red: 0.749, green: 0.788, blue: 0.896),
-	]
-
-	static let noon = [
-		Color(red: 0.184, green: 0.6, blue: 0.9),
-		Color(red: 0.4, green: 0.8, blue: 0.93),
-	]
-
-	static let afternoon = [
-		Color(red: 0, green: 0.353, blue: 0.655),
-		Color(red: 1, green: 0.942, blue: 0.854),
-	]
-
-	static let evening = [
-		Color(red: 0.15, green: 0.261, blue: 0.49),
-		Color(red: 0.424, green: 0.357, blue: 0.482),
-		Color(red: 0.753, green: 0.424, blue: 0.518),
-	]
-
+	/// Deep-blue night floor [zenith, horizon]. The physical sky settles onto these for legibility.
 	static let night = [
 		Color(red: 0.007, green: 0.03, blue: 0.17),
 		Color(red: 0.234, green: 0.446, blue: 0.58),
 	]
 
-	static var colors: [[Color]] {
-		[night, dawn, morning, noon, afternoon, evening, night]
+	private var skyMesh: (gradient: MeshGradient, stops: [Color]) {
+		let solar = effectiveSolar
+		let date = solar?.date ?? .now
+		let sunAltitude = solar?.altitude(at: date) ?? 0
+		let sunX: Double = {
+			guard let solar else { return 0.5 }
+			return min(max(date.timeIntervalSince(solar.startOfDay) / .twentyFourHours, 0), 1)
+		}()
+		return SkyModel.standard.mesh(sunAltitudeDeg: sunAltitude, sunX: sunX)
 	}
 
-	var colors: [[Color]] {
-		let duration = effectiveSolar?.daylightDuration ?? 43200
-		let daylightHours = Int((duration / (60 * 60)) / 2)
-		let amColors = [Self.night, Self.dawn, Self.morning]
-		let pmColors = [Self.afternoon, Self.evening, Self.night]
-
-		let noon = Array(repeating: Self.noon, count: daylightHours)
-
-		if duration <= 0 {
-			return [Self.night, Self.dawn, Self.evening, Self.night]
-		} else if duration >= .twentyFourHours {
-			return [Self.dawn, Self.morning] + noon + [Self.afternoon, Self.evening]
-		}
-
-		return amColors + noon + pmColors
-	}
-
+	/// The vertical colour ramp; `first` is the sky/zenith, `last` the horizon.
+	/// Consumed by `ShareSolarChartView` for the Instagram story background colours.
 	var stops: [Color] {
-		// All Date values are interpreted as absolute instants in time and should be constructed for the local solar time of the location.
-		let sunrise: Date = effectiveSolar?.safeSunrise ?? .now.startOfDay
-		let sunset: Date = effectiveSolar?.safeSunset ?? .now.endOfDay
-		let currentDate: Date = effectiveSolar?.date ?? .now
-		let twilightDuration: TimeInterval = 60 * 180
-
-		let dayStart: Date = sunrise.addingTimeInterval(-twilightDuration)
-		let dayEnd: Date = sunset.addingTimeInterval(twilightDuration)
-		let duration: TimeInterval = dayStart.distance(to: dayEnd)
-
-		let progressStart: Date = sunrise.addingTimeInterval(-twilightDuration / 1.5)
-		let progress: Double = progressStart.distance(to: currentDate) / duration
-
-		let colorCount: Int = colors.count
-		let progressThroughStops: Double = progress * Double(colorCount)
-		let index: Int = min(max(0, Int(floor(progressThroughStops))), colorCount - 1)
-		let nextIndex: Int = max(0, min(colorCount - 1, Int(ceil(progressThroughStops))))
-
-		let stopsA: [Color] = colors[index]
-		let stopsB: [Color] = colors[nextIndex]
-		let progressThroughCurrentStops: Double = progressThroughStops - Double(index)
-
-		let color0: Color = stopsA[0].mix(with: stopsB[0], by: progressThroughCurrentStops)
-		let color1: Color = stopsA[1].mix(with: stopsB[1], by: progressThroughCurrentStops)
-
-		return [color0, color1]
+		skyMesh.stops
 	}
 
-	var body: LinearGradient {
-		LinearGradient(colors: stops, startPoint: .top, endPoint: .bottom)
+	var body: MeshGradient {
+		skyMesh.gradient
 	}
 }
+
+// MARK: - Previews
 
 private struct PreviewContainer: View {
 	@Environment(\.timeZone) var timeZone
@@ -160,8 +323,61 @@ private struct PreviewContainer: View {
 	}
 }
 
-#Preview {
+/// Sweeps the sun from below the horizon to overhead so the physical model can be eyeballed directly.
+private struct AltitudeSweepPreview: View {
+	let altitudes = stride(from: 80.0, through: -20.0, by: -12.5)
+
+	var body: some View {
+		VStack(spacing: 0) {
+			ForEach(Array(altitudes), id: \.self) { altitude in
+				ZStack {
+					SkyModel.standard.mesh(sunAltitudeDeg: altitude, sunX: 0.5).gradient
+					Text("\(Int(altitude))°")
+						.font(.headline.monospacedDigit())
+						.foregroundStyle(.white)
+						.shadow(radius: 2)
+				}
+			}
+		}
+	}
+}
+
+/// Interactive tuning surface for the model's sun altitude and horizontal position.
+private struct SkyModelSliderPreview: View {
+	@State private var altitude = 8.0
+	@State private var sunX = 0.5
+
+	var body: some View {
+		VStack {
+			SkyModel.standard.mesh(sunAltitudeDeg: altitude, sunX: sunX).gradient
+				.ignoresSafeArea()
+				.overlay(alignment: .bottom) {
+					VStack(alignment: .leading) {
+						Text("Altitude \(altitude, format: .number.precision(.fractionLength(1)))°")
+						Slider(value: $altitude, in: -20 ... 90)
+						Text("Sun X \(sunX, format: .number.precision(.fractionLength(2)))")
+						Slider(value: $sunX, in: 0 ... 1)
+					}
+					.padding()
+					.background(.thinMaterial, in: .rect(cornerRadius: 12))
+					.padding()
+					.foregroundStyle(.white)
+				}
+		}
+	}
+}
+
+#Preview("Latitude sweep") {
 	ScrollView {
 		PreviewContainer()
 	}
+}
+
+#Preview("Altitude sweep") {
+	AltitudeSweepPreview()
+		.ignoresSafeArea()
+}
+
+#Preview("Tuning") {
+	SkyModelSliderPreview()
 }

--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -26,8 +26,9 @@ import SwiftUI
 struct SkyModel {
 	/// Rayleigh scattering coefficient per RGB wavelength (1/m).
 	var rayleigh = SIMD3<Double>(5.8e-6, 13.5e-6, 33.1e-6)
-	/// Mie scattering coefficient (1/m).
-	var mie = 21e-6
+	/// Mie scattering coefficient (1/m). Lower keeps the daytime sky bluer and the horizon cleaner
+	/// (less neutral aerosol haze).
+	var mie = 13e-6
 	/// Henyey–Greenstein asymmetry: how tightly the Mie glow hugs the sun (0…1).
 	var mieG = 0.76
 	/// Ozone absorption per RGB wavelength (1/m) — deepens twilight blues and purples.
@@ -41,6 +42,9 @@ struct SkyModel {
 	var sunIntensity = 22.0
 	/// Multiplier applied before tone-mapping. The main lever for overall brightness.
 	var exposure = 3.0
+	/// Faint skylight floor added before tone-mapping so night settles into a deep navy rather than
+	/// pure black, and the day→night ramp stays smooth instead of popping to black.
+	var ambientRadiance = SIMD3<Double>(0.0015, 0.003, 0.008)
 
 	var viewSamples = 16
 	var lightSamples = 8
@@ -48,8 +52,11 @@ struct SkyModel {
 	/// Mesh dimensions. A denser grid renders the 2-D sun glow more smoothly.
 	var meshWidth = 9
 	var meshHeight = 7
-	/// Highest view elevation sampled (top of the rendered strip), in degrees.
-	var maxElevationDeg = 60.0
+	/// View elevations sampled at the bottom and top of the rendered strip, in degrees. Keeping the
+	/// bottom above the horizon avoids the muddy long-path haze and gives a calmer, more even ramp;
+	/// the dramatic below-horizon darkening is applied by the chart, which knows the horizon line.
+	var minElevationDeg = 6.0
+	var maxElevationDeg = 45.0
 	/// Degrees of scattering angle per unit of normalised distance from the sun anchor.
 	/// Higher values shrink the glow; lower values spread it across the gradient.
 	var glowAngularScaleDeg = 120.0
@@ -129,11 +136,12 @@ struct SkyModel {
 		return (inRayleigh + inMie) * sunIntensity
 	}
 
-	/// Tone-mapped, gamma-encoded sky colour for a view direction.
+	/// Tone-mapped, gamma-encoded sky colour for a view direction, including the ambient skylight floor.
 	func color(sunAltitudeDeg: Double, viewElevationDeg: Double, scatterCosTheta: Double) -> Color {
-		tonemap(radiance(sunAltitudeDeg: sunAltitudeDeg,
-		                 viewElevationDeg: viewElevationDeg,
-		                 scatterCosTheta: scatterCosTheta))
+		let scattered = radiance(sunAltitudeDeg: sunAltitudeDeg,
+		                         viewElevationDeg: viewElevationDeg,
+		                         scatterCosTheta: scatterCosTheta)
+		return tonemap(scattered + ambientRadiance)
 	}
 
 	// MARK: Mesh
@@ -157,8 +165,8 @@ struct SkyModel {
 		for row in 0 ..< h {
 			let rowY = Double(row) / Double(h - 1)
 			let elevationFraction = 1 - rowY
-			// Bias sampling toward the horizon, where colour varies most.
-			let elevation = maxElevationDeg * elevationFraction * elevationFraction
+			// Even ramp between the horizon-ish bottom and the higher top.
+			let elevation = minElevationDeg + (maxElevationDeg - minElevationDeg) * elevationFraction
 			for col in 0 ..< w {
 				let colX = Double(col) / Double(w - 1)
 				let distance = hypot(colX - Double(sunAnchor.x), rowY - Double(sunAnchor.y))

--- a/Solstice/List View/GraphicalLocationListRow.swift
+++ b/Solstice/List View/GraphicalLocationListRow.swift
@@ -25,6 +25,8 @@ struct GraphicalLocationListRow<Location: ObservableLocation>: View {
 			.padding()
 			.background {
 				solar?.view
+					// Darken slightly so the plusLighter row text stays legible over bright skies.
+					.overlay { Color.black.opacity(0.18) }
 					.clipShape(.rect(cornerRadius: 20, style: .continuous))
 			}
 		#if os(iOS)

--- a/SolsticeTests/SkyModelTests.swift
+++ b/SolsticeTests/SkyModelTests.swift
@@ -44,14 +44,15 @@ struct SkyModelTests {
 		#expect(redToBlue(3) > redToBlue(30))
 	}
 
-	@Test("The glow brightens toward the sun (higher scattering cosine)")
+	@Test("The glow peaks looking straight at the sun")
 	func glowPeaksTowardTheSun() {
 		func brightness(_ cosTheta: Double) -> Double {
 			luminance(model.radiance(sunAltitudeDeg: 20, viewElevationDeg: 20, scatterCosTheta: cosTheta))
 		}
-		// Forward Mie scattering: brightest looking straight at the sun, dimmest facing away.
+		// The forward-Mie lobe makes looking at the sun the brightest direction. (Rayleigh alone is
+		// symmetric, so side-scatter is not necessarily dimmer than back-scatter — don't assert that.)
 		#expect(brightness(1) > brightness(0))
-		#expect(brightness(0) > brightness(-1))
+		#expect(brightness(1) > brightness(-1))
 	}
 
 	@Test("Physical sky goes dark once the sun is well below the horizon")

--- a/SolsticeTests/SkyModelTests.swift
+++ b/SolsticeTests/SkyModelTests.swift
@@ -119,6 +119,13 @@ struct SkyModelTests {
 		#expect(luminance(nearest: 1) == luminance(nearest: 0))
 	}
 
+	@Test("High-sun horizon stays blue rather than yellow-green")
+	func highSunHorizonStaysBlue() {
+		// Single scattering alone goes green here; the multiple-scattering fill keeps it blue.
+		let rgb = model.radiance(sunAltitudeDeg: 60, viewElevationDeg: model.minElevationDeg, scatterCosTheta: 0.3)
+		#expect(rgb.z > rgb.y)
+	}
+
 	@Test("Radiance stays finite and non-negative across every angle")
 	func radianceNeverNaN() {
 		for sunAltitude in stride(from: -90.0, through: 90, by: 7.5) {

--- a/SolsticeTests/SkyModelTests.swift
+++ b/SolsticeTests/SkyModelTests.swift
@@ -157,10 +157,11 @@ struct SkyModelTests {
 			date.timeIntervalSince(start) / .twentyFourHours
 		}
 
-		// Every stop strictly inside the evening civil-twilight band must share one colour.
+		// Every stop strictly inside the evening civil-twilight band must share one colour. The
+		// filter admits the boundary pairs' inner stops (±0.0001), which carry the band's colour.
 		let bandStart = try fraction(#require(solar.sunset))
 		let bandEnd = try fraction(#require(solar.civilSunset))
-		let band = stops.filter { $0.location > bandStart + 0.0002 && $0.location < bandEnd - 0.0002 }
+		let band = stops.filter { $0.location > bandStart + 0.00005 && $0.location < bandEnd - 0.00005 }
 		#expect(band.count >= 1)
 		for stop in band {
 			#expect(stop.color == band[0].color)

--- a/SolsticeTests/SkyModelTests.swift
+++ b/SolsticeTests/SkyModelTests.swift
@@ -64,7 +64,7 @@ struct SkyModelTests {
 
 	@Test("Mesh is well formed with finite colours")
 	func meshWellFormed() {
-		let mesh = model.mesh(sunAltitudeDeg: 20, sunAnchor: UnitPoint(x: 0.3, y: 0.4))
+		let mesh = model.mesh(sunAltitudeDeg: 20)
 		#expect(mesh.stops.count == model.meshHeight)
 
 		let env = EnvironmentValues()
@@ -80,7 +80,7 @@ struct SkyModelTests {
 
 	@Test("Ground band below the horizon is darker than the sky above it, and fades with depth")
 	func groundBandDarkerThanHorizonSky() {
-		let mesh = model.mesh(sunAltitudeDeg: 30, sunAnchor: UnitPoint(x: 0.5, y: 0.3), horizonFraction: 0.6)
+		let mesh = model.mesh(sunAltitudeDeg: 30, horizonFraction: 0.6)
 		#expect(mesh.stops.count == model.meshHeight)
 
 		// Rows: [0 ..< meshHeight - 2] sky (top → horizon), then two ground rows.
@@ -121,20 +121,77 @@ struct SkyModelTests {
 
 	@Test("Cached mesh matches a direct render of the quantised inputs")
 	func cachedMeshMatchesDirectRender() {
-		let cached = model.cachedMesh(sunAltitudeDeg: 17.03,
-		                              sunAnchor: UnitPoint(x: 0.31, y: 0.52),
-		                              horizonFraction: 0.61)
+		let cached = model.cachedMesh(sunAltitudeDeg: 17.03, horizonFraction: 0.61)
 		let direct = model.mesh(sunAltitudeDeg: (17.03 * 10).rounded() / 10,
-		                        sunAnchor: UnitPoint(x: (0.31 * 128).rounded() / 128,
-		                                             y: (0.52 * 128).rounded() / 128),
 		                        horizonFraction: (0.61 * 256).rounded() / 256)
 		#expect(cached.stops == direct.stops)
 
 		// A second call must return the identical memoized result.
-		let secondHit = model.cachedMesh(sunAltitudeDeg: 17.03,
-		                                 sunAnchor: UnitPoint(x: 0.31, y: 0.52),
-		                                 horizonFraction: 0.61)
+		let secondHit = model.cachedMesh(sunAltitudeDeg: 17.03, horizonFraction: 0.61)
 		#expect(secondHit.stops == cached.stops)
+	}
+
+	@Test("Glow stops peak at the centre and fade to nothing")
+	func glowStopsFadeOutward() {
+		let stops = SkyModel.standard.glowStops(sunAltitudeDeg: 20)
+		#expect(stops.first?.location == 0)
+		#expect(stops.last?.location == 1)
+
+		let luminances = stops.map { resolvedLuminance($0.color) }
+		let first = luminances[0], mid = luminances[luminances.count / 2], last = luminances[luminances.count - 1]
+		#expect(first > mid)
+		#expect(mid >= last)
+		// The outermost stop is (near) black, so the additive layer vanishes at its edge.
+		#expect(last < 0.02)
+	}
+
+	@Test("Below-horizon dial segments are solid per twilight band")
+	func dialTwilightSegmentsAreSolid() throws {
+		let timeZone = try #require(TimeZone(identifier: "Europe/London"))
+		let date = try #require(DateComponents(calendar: Calendar(identifier: .gregorian),
+		                                       timeZone: timeZone,
+		                                       year: 2026, month: 6, day: 21, hour: 12).date)
+		let coordinate = CLLocationCoordinate2D(latitude: 51.5, longitude: -0.1)
+		let solar = try #require(NTSolar(for: date, coordinate: coordinate, timeZone: timeZone))
+
+		let stops = SkyModel.standard.dialStops(for: solar)
+		let start = solar.startOfDay
+		func fraction(_ date: Date) -> Double {
+			date.timeIntervalSince(start) / .twentyFourHours
+		}
+
+		// Every stop strictly inside the evening civil-twilight band must share one colour.
+		let bandStart = try fraction(#require(solar.sunset))
+		let bandEnd = try fraction(#require(solar.civilSunset))
+		let band = stops.filter { $0.location > bandStart + 0.0002 && $0.location < bandEnd - 0.0002 }
+		#expect(band.count >= 1)
+		for stop in band {
+			#expect(stop.color == band[0].color)
+		}
+
+		// And it must be a saturated blue, not grey: blue well above red.
+		let civil = try #require(band.first).color.resolve(in: EnvironmentValues())
+		#expect(civil.blue > civil.red * 2)
+	}
+
+	@Test("Below-horizon wedges brighten with the current daylight")
+	func dialWedgesBrightenWithDaylight() throws {
+		let timeZone = try #require(TimeZone(identifier: "Europe/London"))
+		let coordinate = CLLocationCoordinate2D(latitude: 51.5, longitude: -0.1)
+
+		func ring(hour: Int) throws -> [Gradient.Stop] {
+			let date = try #require(DateComponents(calendar: Calendar(identifier: .gregorian),
+			                                       timeZone: timeZone,
+			                                       year: 2026, month: 6, day: 21, hour: hour).date)
+			let solar = try #require(NTSolar(for: date, coordinate: coordinate, timeZone: timeZone))
+			return SkyModel.standard.dialStops(for: solar)
+		}
+
+		// The first stop sits at the midnight angle, inside the night wedge: it should be lifted
+		// while the sun is high and settle back to the deep floor at night.
+		let duringDay = try #require(try ring(hour: 13).first)
+		let duringNight = try #require(try ring(hour: 0).first)
+		#expect(resolvedLuminance(duringDay.color) > resolvedLuminance(duringNight.color))
 	}
 
 	@Test("High-sun horizon stays blue rather than yellow-green")

--- a/SolsticeTests/SkyModelTests.swift
+++ b/SolsticeTests/SkyModelTests.swift
@@ -119,6 +119,24 @@ struct SkyModelTests {
 		#expect(luminance(nearest: 1) == luminance(nearest: 0))
 	}
 
+	@Test("Cached mesh matches a direct render of the quantised inputs")
+	func cachedMeshMatchesDirectRender() {
+		let cached = model.cachedMesh(sunAltitudeDeg: 17.03,
+		                              sunAnchor: UnitPoint(x: 0.31, y: 0.52),
+		                              horizonFraction: 0.61)
+		let direct = model.mesh(sunAltitudeDeg: (17.03 * 10).rounded() / 10,
+		                        sunAnchor: UnitPoint(x: (0.31 * 128).rounded() / 128,
+		                                             y: (0.52 * 128).rounded() / 128),
+		                        horizonFraction: (0.61 * 256).rounded() / 256)
+		#expect(cached.stops == direct.stops)
+
+		// A second call must return the identical memoized result.
+		let secondHit = model.cachedMesh(sunAltitudeDeg: 17.03,
+		                                 sunAnchor: UnitPoint(x: 0.31, y: 0.52),
+		                                 horizonFraction: 0.61)
+		#expect(secondHit.stops == cached.stops)
+	}
+
 	@Test("High-sun horizon stays blue rather than yellow-green")
 	func highSunHorizonStaysBlue() {
 		// Single scattering alone goes green here; the multiple-scattering fill keeps it blue.

--- a/SolsticeTests/SkyModelTests.swift
+++ b/SolsticeTests/SkyModelTests.swift
@@ -97,16 +97,19 @@ struct SkyModelTests {
 		}
 	}
 
-	@Test("Dial stops are brighter at noon than at midnight, and the ring closes seamlessly")
-	func dialStopsDayNightContrast() throws {
+	/// London on the 2026 June solstice at the given hour — the shared fixture for dial tests.
+	private func londonSolar(hour: Int) throws -> NTSolar {
 		let timeZone = try #require(TimeZone(identifier: "Europe/London"))
 		let date = try #require(DateComponents(calendar: Calendar(identifier: .gregorian),
 		                                       timeZone: timeZone,
-		                                       year: 2026, month: 6, day: 21, hour: 12).date)
+		                                       year: 2026, month: 6, day: 21, hour: hour).date)
 		let coordinate = CLLocationCoordinate2D(latitude: 51.5, longitude: -0.1)
-		let solar = try #require(NTSolar(for: date, coordinate: coordinate, timeZone: timeZone))
+		return try #require(NTSolar(for: date, coordinate: coordinate, timeZone: timeZone))
+	}
 
-		let stops = SkyModel.standard.dialStops(for: solar)
+	@Test("Dial stops are brighter at noon than at midnight, and the ring closes seamlessly")
+	func dialStopsDayNightContrast() throws {
+		let stops = try SkyModel.standard.dialStops(for: londonSolar(hour: 12))
 		#expect(stops.first?.location == 0)
 		#expect(stops.last?.location == 1)
 
@@ -147,13 +150,7 @@ struct SkyModelTests {
 
 	@Test("Below-horizon dial segments are solid per twilight band")
 	func dialTwilightSegmentsAreSolid() throws {
-		let timeZone = try #require(TimeZone(identifier: "Europe/London"))
-		let date = try #require(DateComponents(calendar: Calendar(identifier: .gregorian),
-		                                       timeZone: timeZone,
-		                                       year: 2026, month: 6, day: 21, hour: 12).date)
-		let coordinate = CLLocationCoordinate2D(latitude: 51.5, longitude: -0.1)
-		let solar = try #require(NTSolar(for: date, coordinate: coordinate, timeZone: timeZone))
-
+		let solar = try londonSolar(hour: 12)
 		let stops = SkyModel.standard.dialStops(for: solar)
 		let start = solar.startOfDay
 		func fraction(_ date: Date) -> Double {
@@ -176,21 +173,10 @@ struct SkyModelTests {
 
 	@Test("Below-horizon wedges brighten with the current daylight")
 	func dialWedgesBrightenWithDaylight() throws {
-		let timeZone = try #require(TimeZone(identifier: "Europe/London"))
-		let coordinate = CLLocationCoordinate2D(latitude: 51.5, longitude: -0.1)
-
-		func ring(hour: Int) throws -> [Gradient.Stop] {
-			let date = try #require(DateComponents(calendar: Calendar(identifier: .gregorian),
-			                                       timeZone: timeZone,
-			                                       year: 2026, month: 6, day: 21, hour: hour).date)
-			let solar = try #require(NTSolar(for: date, coordinate: coordinate, timeZone: timeZone))
-			return SkyModel.standard.dialStops(for: solar)
-		}
-
 		// The first stop sits at the midnight angle, inside the night wedge: it should be lifted
 		// while the sun is high and settle back to the deep floor at night.
-		let duringDay = try #require(try ring(hour: 13).first)
-		let duringNight = try #require(try ring(hour: 0).first)
+		let duringDay = try #require(SkyModel.standard.dialStops(for: londonSolar(hour: 13)).first)
+		let duringNight = try #require(SkyModel.standard.dialStops(for: londonSolar(hour: 0)).first)
 		#expect(resolvedLuminance(duringDay.color) > resolvedLuminance(duringNight.color))
 	}
 

--- a/SolsticeTests/SkyModelTests.swift
+++ b/SolsticeTests/SkyModelTests.swift
@@ -19,15 +19,15 @@ struct SkyModelTests {
 
 	@Test("Daylight sky is far brighter than deep twilight")
 	func daylightBrighterThanTwilight() {
-		let day = luminance(model.radiance(sunAltitudeDeg: 45, viewElevationDeg: 80, relativeAzimuthDeg: 0))
-		let twilight = luminance(model.radiance(sunAltitudeDeg: -10, viewElevationDeg: 80, relativeAzimuthDeg: 0))
+		let day = luminance(model.radiance(sunAltitudeDeg: 45, viewElevationDeg: 80, scatterCosTheta: 0.5))
+		let twilight = luminance(model.radiance(sunAltitudeDeg: -10, viewElevationDeg: 80, scatterCosTheta: 0.5))
 		#expect(day > twilight)
 	}
 
 	@Test("Zenith brightness increases as the sun climbs")
 	func brightnessMonotonicWithAltitude() {
 		func zenith(_ altitude: Double) -> Double {
-			luminance(model.radiance(sunAltitudeDeg: altitude, viewElevationDeg: 80, relativeAzimuthDeg: 0))
+			luminance(model.radiance(sunAltitudeDeg: altitude, viewElevationDeg: 80, scatterCosTheta: 0.5))
 		}
 		let samples = [5.0, 20, 40, 60].map(zenith)
 		for (lower, higher) in zip(samples, samples.dropFirst()) {
@@ -38,39 +38,31 @@ struct SkyModelTests {
 	@Test("The horizon reddens as the sun descends")
 	func horizonRedensAtLowSun() {
 		func redToBlue(_ altitude: Double) -> Double {
-			let rgb = model.radiance(sunAltitudeDeg: altitude, viewElevationDeg: 2, relativeAzimuthDeg: 0)
+			let rgb = model.radiance(sunAltitudeDeg: altitude, viewElevationDeg: 2, scatterCosTheta: 1)
 			return rgb.x / max(rgb.z, 1e-12)
 		}
 		#expect(redToBlue(3) > redToBlue(30))
 	}
 
-	@Test("Physical sky goes dark once the sun is well below the horizon")
-	func nightPhysicalGoesDark() {
-		let night = luminance(model.radiance(sunAltitudeDeg: -30, viewElevationDeg: 30, relativeAzimuthDeg: 0))
-		#expect(night < 1e-3)
+	@Test("The glow brightens toward the sun (higher scattering cosine)")
+	func glowPeaksTowardTheSun() {
+		func brightness(_ cosTheta: Double) -> Double {
+			luminance(model.radiance(sunAltitudeDeg: 20, viewElevationDeg: 20, scatterCosTheta: cosTheta))
+		}
+		// Forward Mie scattering: brightest looking straight at the sun, dimmest facing away.
+		#expect(brightness(1) > brightness(0))
+		#expect(brightness(0) > brightness(-1))
 	}
 
-	@Test("Night floor keeps the rendered sky legible and blue")
-	func nightFloorRemainsVisible() throws {
-		let mesh = model.mesh(sunAltitudeDeg: -30, sunX: 0.5)
-		#expect(mesh.stops.count == model.meshHeight)
-
-		let env = EnvironmentValues()
-		let resolved = mesh.stops.map { $0.resolve(in: env) }
-
-		// Every night stop is blue-dominant (deep-blue floor, never a neutral black).
-		for color in resolved {
-			#expect(color.blue >= color.red)
-		}
-		// The horizon stop stays clearly visible.
-		let horizon = try #require(resolved.last)
-		let horizonLuminance = 0.2126 * Double(horizon.red) + 0.7152 * Double(horizon.green) + 0.0722 * Double(horizon.blue)
-		#expect(horizonLuminance > 0.01)
+	@Test("Physical sky goes dark once the sun is well below the horizon")
+	func nightPhysicalGoesDark() {
+		let night = luminance(model.radiance(sunAltitudeDeg: -30, viewElevationDeg: 30, scatterCosTheta: 0.5))
+		#expect(night < 1e-3)
 	}
 
 	@Test("Mesh is well formed with finite colours")
 	func meshWellFormed() {
-		let mesh = model.mesh(sunAltitudeDeg: 20, sunX: 0.3)
+		let mesh = model.mesh(sunAltitudeDeg: 20, sunAnchor: UnitPoint(x: 0.3, y: 0.4))
 		#expect(mesh.stops.count == model.meshHeight)
 
 		let env = EnvironmentValues()
@@ -83,10 +75,10 @@ struct SkyModelTests {
 	func radianceNeverNaN() {
 		for sunAltitude in stride(from: -90.0, through: 90, by: 7.5) {
 			for viewElevation in stride(from: 0.0, through: 90, by: 15) {
-				for azimuth in stride(from: -180.0, through: 180, by: 45) {
+				for cosTheta in stride(from: -1.0, through: 1, by: 0.25) {
 					let rgb = model.radiance(sunAltitudeDeg: sunAltitude,
 					                         viewElevationDeg: viewElevation,
-					                         relativeAzimuthDeg: azimuth)
+					                         scatterCosTheta: cosTheta)
 					#expect(rgb.x.isFinite && rgb.y.isFinite && rgb.z.isFinite)
 					#expect(rgb.x >= 0 && rgb.y >= 0 && rgb.z >= 0)
 				}

--- a/SolsticeTests/SkyModelTests.swift
+++ b/SolsticeTests/SkyModelTests.swift
@@ -5,6 +5,7 @@
 //  Exercises the physics-based sky model behind SkyGradient.
 //
 
+import CoreLocation
 import Foundation
 @testable import Solstice
 import SwiftUI
@@ -70,6 +71,52 @@ struct SkyModelTests {
 		for color in mesh.stops.map({ $0.resolve(in: env) }) {
 			#expect(color.red.isFinite && color.green.isFinite && color.blue.isFinite)
 		}
+	}
+
+	private func resolvedLuminance(_ color: Color) -> Double {
+		let resolved = color.resolve(in: EnvironmentValues())
+		return 0.2126 * Double(resolved.red) + 0.7152 * Double(resolved.green) + 0.0722 * Double(resolved.blue)
+	}
+
+	@Test("Ground band below the horizon is darker than the sky above it, and fades with depth")
+	func groundBandDarkerThanHorizonSky() {
+		let mesh = model.mesh(sunAltitudeDeg: 30, sunAnchor: UnitPoint(x: 0.5, y: 0.3), horizonFraction: 0.6)
+		#expect(mesh.stops.count == model.meshHeight)
+
+		// Rows: [0 ..< meshHeight - 2] sky (top → horizon), then two ground rows.
+		let horizonSky = resolvedLuminance(mesh.stops[model.meshHeight - 3])
+		let groundTop = resolvedLuminance(mesh.stops[model.meshHeight - 2])
+		let groundBottom = resolvedLuminance(mesh.stops[model.meshHeight - 1])
+
+		#expect(groundTop < horizonSky)
+		#expect(groundBottom < groundTop)
+
+		let env = EnvironmentValues()
+		for color in mesh.stops.map({ $0.resolve(in: env) }) {
+			#expect(color.red.isFinite && color.green.isFinite && color.blue.isFinite)
+		}
+	}
+
+	@Test("Dial stops are brighter at noon than at midnight, and the ring closes seamlessly")
+	func dialStopsDayNightContrast() throws {
+		let timeZone = try #require(TimeZone(identifier: "Europe/London"))
+		let date = try #require(DateComponents(calendar: Calendar(identifier: .gregorian),
+		                                       timeZone: timeZone,
+		                                       year: 2026, month: 6, day: 21, hour: 12).date)
+		let coordinate = CLLocationCoordinate2D(latitude: 51.5, longitude: -0.1)
+		let solar = try #require(NTSolar(for: date, coordinate: coordinate, timeZone: timeZone))
+
+		let stops = SkyModel.standard.dialStops(for: solar)
+		#expect(stops.first?.location == 0)
+		#expect(stops.last?.location == 1)
+
+		func luminance(nearest location: Double) -> Double {
+			let stop = stops.min { abs($0.location - location) < abs($1.location - location) }!
+			return resolvedLuminance(stop.color)
+		}
+
+		#expect(luminance(nearest: 0.5) > luminance(nearest: 0))
+		#expect(luminance(nearest: 1) == luminance(nearest: 0))
 	}
 
 	@Test("Radiance stays finite and non-negative across every angle")

--- a/SolsticeTests/SkyModelTests.swift
+++ b/SolsticeTests/SkyModelTests.swift
@@ -1,0 +1,96 @@
+//
+//  SkyModelTests.swift
+//  SolsticeTests
+//
+//  Exercises the physics-based sky model behind SkyGradient.
+//
+
+import Foundation
+@testable import Solstice
+import SwiftUI
+import Testing
+
+struct SkyModelTests {
+	let model = SkyModel.standard
+
+	private func luminance(_ rgb: SIMD3<Double>) -> Double {
+		0.2126 * rgb.x + 0.7152 * rgb.y + 0.0722 * rgb.z
+	}
+
+	@Test("Daylight sky is far brighter than deep twilight")
+	func daylightBrighterThanTwilight() {
+		let day = luminance(model.radiance(sunAltitudeDeg: 45, viewElevationDeg: 80, relativeAzimuthDeg: 0))
+		let twilight = luminance(model.radiance(sunAltitudeDeg: -10, viewElevationDeg: 80, relativeAzimuthDeg: 0))
+		#expect(day > twilight)
+	}
+
+	@Test("Zenith brightness increases as the sun climbs")
+	func brightnessMonotonicWithAltitude() {
+		func zenith(_ altitude: Double) -> Double {
+			luminance(model.radiance(sunAltitudeDeg: altitude, viewElevationDeg: 80, relativeAzimuthDeg: 0))
+		}
+		let samples = [5.0, 20, 40, 60].map(zenith)
+		for (lower, higher) in zip(samples, samples.dropFirst()) {
+			#expect(higher > lower)
+		}
+	}
+
+	@Test("The horizon reddens as the sun descends")
+	func horizonRedensAtLowSun() {
+		func redToBlue(_ altitude: Double) -> Double {
+			let rgb = model.radiance(sunAltitudeDeg: altitude, viewElevationDeg: 2, relativeAzimuthDeg: 0)
+			return rgb.x / max(rgb.z, 1e-12)
+		}
+		#expect(redToBlue(3) > redToBlue(30))
+	}
+
+	@Test("Physical sky goes dark once the sun is well below the horizon")
+	func nightPhysicalGoesDark() {
+		let night = luminance(model.radiance(sunAltitudeDeg: -30, viewElevationDeg: 30, relativeAzimuthDeg: 0))
+		#expect(night < 1e-3)
+	}
+
+	@Test("Night floor keeps the rendered sky legible and blue")
+	func nightFloorRemainsVisible() throws {
+		let mesh = model.mesh(sunAltitudeDeg: -30, sunX: 0.5)
+		#expect(mesh.stops.count == model.meshHeight)
+
+		let env = EnvironmentValues()
+		let resolved = mesh.stops.map { $0.resolve(in: env) }
+
+		// Every night stop is blue-dominant (deep-blue floor, never a neutral black).
+		for color in resolved {
+			#expect(color.blue >= color.red)
+		}
+		// The horizon stop stays clearly visible.
+		let horizon = try #require(resolved.last)
+		let horizonLuminance = 0.2126 * Double(horizon.red) + 0.7152 * Double(horizon.green) + 0.0722 * Double(horizon.blue)
+		#expect(horizonLuminance > 0.01)
+	}
+
+	@Test("Mesh is well formed with finite colours")
+	func meshWellFormed() {
+		let mesh = model.mesh(sunAltitudeDeg: 20, sunX: 0.3)
+		#expect(mesh.stops.count == model.meshHeight)
+
+		let env = EnvironmentValues()
+		for color in mesh.stops.map({ $0.resolve(in: env) }) {
+			#expect(color.red.isFinite && color.green.isFinite && color.blue.isFinite)
+		}
+	}
+
+	@Test("Radiance stays finite and non-negative across every angle")
+	func radianceNeverNaN() {
+		for sunAltitude in stride(from: -90.0, through: 90, by: 7.5) {
+			for viewElevation in stride(from: 0.0, through: 90, by: 15) {
+				for azimuth in stride(from: -180.0, through: 180, by: 45) {
+					let rgb = model.radiance(sunAltitudeDeg: sunAltitude,
+					                         viewElevationDeg: viewElevation,
+					                         relativeAzimuthDeg: azimuth)
+					#expect(rgb.x.isFinite && rgb.y.isFinite && rgb.z.isFinite)
+					#expect(rgb.x >= 0 && rgb.y >= 0 && rgb.z >= 0)
+				}
+			}
+		}
+	}
+}

--- a/watchOS/ContentView.swift
+++ b/watchOS/ContentView.swift
@@ -97,6 +97,13 @@ struct ContentView: View {
 				placeholderView
 			}
 		}
+		.task(id: scenePhase) {
+			// A suspended app misses the TimeMachine's minutely reference-date ticks; waking
+			// after hours would otherwise show the pre-sleep sky until the next tick lands.
+			if scenePhase == .active {
+				timeMachine.updateReferenceDate()
+			}
+		}
 		.resolveDeepLink(sortedItems)
 		.withTimeMachine(.solsticeTimeMachine)
 		.task {


### PR DESCRIPTION
## What

Replaces `SkyGradient`'s six hand-picked time-of-day colour keyframes with a physically-motivated sky model rendered as a SwiftUI `MeshGradient`. The colours now fall out of the sun's actual altitude and position instead of a clock-driven lerp between fixed palettes — a warm glow anchored to the sun (like the Apple Watch solar faces), realistic twilight, and a legible deep-blue night.

Continues (and completes) an earlier Xcode-agent session that scoped the direction but died before writing code.

## How

- **`SkyModel`** (co-located in `SkyGradient.swift`) — a CPU single-scattering atmosphere: Rayleigh + Mie (Henyey-Greenstein forward lobe) + ozone absorption, Nishita-style ray march through a spherical-shell atmosphere, keyed on sun altitude. `radiance(...)` → linear RGB → Reinhard + sRGB tone-map → `Color`. No Metal, so one implementation covers the main app, widgets, and watchOS at every deployment floor (iOS 18.5 / macOS 15.6 / watchOS 11.6 / visionOS 2).
- **`mesh(sunAltitudeDeg:sunX:)`** builds a 7×5 `MeshGradient`: rows biased toward the horizon (where colour varies most), columns' azimuth measured relative to the sun so the Mie glow anchors at the sun's horizontal position. `sunX` uses the same time-of-day fraction as `DaylightChart`'s x-axis, so the glow lines up with the on-chart sun.
- **Night floor** — physical twilight blends to the old `night` palette below −6°…−18° sun altitude, keeping white `.plusLighter` chart content legible.
- **`SkyGradient`** keeps its type name, `View + ShapeStyle` conformance, `init(ntSolar:)`, and `stops` accessor (Instagram story export reads `stops.first/.last`), so **every existing surface upgrades with no call-site changes**. Sun altitude from `NTSolar.altitude(at:)`.
- All physics constants live in `SkyModel.standard` for on-device tuning (`exposure`, `mie`/`mieG`, `nightFloor`).

## Tests & tuning

- `SolsticeTests/SkyModelTests.swift` (Swift Testing): daylight brighter than twilight, zenith brightness rises with sun altitude, horizon reddens as the sun descends, physical sky → ~0 well below the horizon, night floor stays legible/blue, mesh well-formed, radiance finite/non-negative across a full angle sweep.
- Added altitude-sweep and interactive slider previews to `SkyGradient.swift` for tuning in Xcode Previews.

## Verification note

Built and authored in a **remote session with no local Xcode** — not yet compiled locally. Please rely on the Xcode Cloud build to confirm it compiles across all targets. Two things to eyeball on device:
1. The one ShapeStyle-typed call site, watchOS `DetailView.swift:90` (`containerBackground(SkyGradient(…), for: .navigation)`) — confirms the `ShapeStyle`-via-`View` bridge still resolves now that `body` returns `MeshGradient` instead of `LinearGradient`.
2. That the mesh actually renders in the widget/watch `containerBackground`, and that noon isn't blown out / night stays readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)