### PR TITLE
Vary sky colour by sunrise/sunset and location via aerosol turbidity

### DIFF
--- a/Solstice/Helper Views/SkyGradient.swift
+++ b/Solstice/Helper Views/SkyGradient.swift
@@ -136,6 +136,45 @@ struct SkyModel {
 		return model
 	}()
 
+	// MARK: Turbidity
+
+	/// A copy tuned for atmospheric turbidity — how much aerosol (dust, haze) loads the air.
+	///
+	/// `1.0` reproduces `self` exactly. Above 1 is hazier and warmer (a dusty evening); below 1 is
+	/// cleaner and cooler (settled morning air). This is what makes a sunset read oranger than a
+	/// sunrise at the same altitude, since the geometry alone is symmetric.
+	///
+	/// Only the Mie (aerosol) terms and ozone move, and gently:
+	/// - `mie` scales the warm forward in-scatter. Raising it adds a glow that arrives *reddened*,
+	///   because the near-horizon light it scatters has already lost its blue along the long path —
+	///   so more aerosol reads orange at the horizon, not merely grey. (`mieExt` is derived from
+	///   `mie` inside `radiance`, so haze and glow stay coupled.)
+	/// - `mieG` tightens the warm lobe slightly on the hazy side.
+	/// - `ozone` lifts a touch on the clean side, letting the twilight pink/violet show through.
+	///
+	/// Clamped so the sky never turns garish however extreme the derived turbidity.
+	func adjusted(turbidity: Double) -> SkyModel {
+		let t = min(max(turbidity, 0.80), 1.25)
+		guard t != 1 else { return self }
+		var model = self
+		model.mie = mie * t
+		model.mieG = min(0.86, mieG + 0.03 * (t - 1))
+		model.ozone = ozone * (1 + 0.25 * (1 - t))
+		return model
+	}
+
+	/// Atmospheric turbidity for a place and time of day, from the only signals available cheaply:
+	/// latitude and whether the sun is rising or setting. No new data sources.
+	///
+	/// - A climate term makes the warm, humid tropics hazier and the cool poles crisper.
+	/// - A diurnal term makes mornings cleaner (overnight settling) and evenings hazier (a day of
+	///   convection lifting dust) — the everyday reason dawn skews pink and dusk skews orange.
+	static func turbidity(latitude: Double, ascending: Bool) -> Double {
+		let climate = 1.0 + 0.08 * cos(latitude * .pi / 180)
+		let diurnal = ascending ? -0.12 : 0.12
+		return climate + diurnal
+	}
+
 	// MARK: Radiance
 
 	/// Linear (pre-tone-map) RGB radiance for a view direction, given the sun's altitude.
@@ -425,16 +464,25 @@ struct SkyModel {
 	/// steps darker toward night — the Watch solar dial look. Stop locations are fractions of a day
 	/// from midnight; align them using the chart's midnight angle.
 	func dialStops(for solar: NTSolar, sampleCount: Int = 48) -> [Gradient.Stop] {
-		let coarse = coarseMarch
+		// The morning arc is rendered from cleaner (cooler, pinker) air and the evening arc from
+		// hazier (warmer, oranger) air, so the ring carries the sunrise/sunset asymmetry too. Both
+		// are the same coarse march with only their turbidity differing.
+		let lat = solar.coordinate.latitude
+		let ascCoarse = adjusted(turbidity: SkyModel.turbidity(latitude: lat, ascending: true)).coarseMarch
+		let descCoarse = adjusted(turbidity: SkyModel.turbidity(latitude: lat, ascending: false)).coarseMarch
 
 		// The wedges brighten with the daylight at the *current* moment, not the wedge's own time.
 		let daylight = daylightFactor(sunAltitudeDeg: solar.altitude(at: solar.date))
 
-		/// Colour for one dial angle; depends only on the sun's altitude at that time.
-		func stopColor(altitudeDeg: Double) -> Color {
+		/// Colour for one dial angle; depends on the sun's altitude at that time and, above the
+		/// horizon, on whether it is rising (cooler) or setting (warmer).
+		func stopColor(altitudeDeg: Double, ascending: Bool) -> Color {
+			let coarse = ascending ? ascCoarse : descCoarse
+
 			// Below the horizon the ring is stylised: solid, saturated sky-blue wedges stepping
 			// darker toward night, lifted by the current daylight. Marched twilight reads grey
-			// here (its reddened transmittance desaturates the blues), so the wedges don't use it.
+			// here (its reddened transmittance desaturates the blues), so the wedges don't use it —
+			// and being turbidity-invariant, they read identically on the morning and evening sides.
 			let bandLuminance: Double = switch altitudeDeg {
 			case (-6)...: dialBandLuminances.x // civil twilight
 			case (-12)...: dialBandLuminances.y // nautical twilight
@@ -459,7 +507,9 @@ struct SkyModel {
 		var stops = (0 ..< sampleCount).map { i in
 			let fraction = Double(i) / Double(sampleCount)
 			let date = start.addingTimeInterval(fraction * .twentyFourHours)
-			return Gradient.Stop(color: stopColor(altitudeDeg: solar.altitude(at: date)), location: fraction)
+			return Gradient.Stop(color: stopColor(altitudeDeg: solar.altitude(at: date),
+			                                       ascending: solar.isAscending(at: date)),
+			                     location: fraction)
 		}
 
 		// Crisp wedge edges: a near-coincident pair of stops pins each twilight boundary. Pairs
@@ -515,8 +565,10 @@ struct SkyModel {
 		}
 
 		for boundary in boundaries {
-			let earlier = stopColor(altitudeDeg: boundary.thresholdDeg + (boundary.rising ? -0.5 : 0.5))
-			let later = stopColor(altitudeDeg: boundary.thresholdDeg + (boundary.rising ? 0.5 : -0.5))
+			let earlier = stopColor(altitudeDeg: boundary.thresholdDeg + (boundary.rising ? -0.5 : 0.5),
+			                        ascending: boundary.rising)
+			let later = stopColor(altitudeDeg: boundary.thresholdDeg + (boundary.rising ? 0.5 : -0.5),
+			                      ascending: boundary.rising)
 			stops.append(Gradient.Stop(color: earlier, location: max(0, boundary.fraction - 0.0001)))
 			stops.append(Gradient.Stop(color: later, location: min(1, boundary.fraction + 0.0001)))
 		}
@@ -627,10 +679,19 @@ final class SkyRenderCache<Key: Hashable, Value>: @unchecked Sendable {
 private struct SkyMeshKey: Hashable {
 	let altitude: Int
 	let horizon: Int?
+	/// Quantised turbidity (× 50, so ~0.02 steps). Locations and morning/evening produce only a
+	/// handful of buckets, and a single-location scrub holds turbidity fixed, so scrubbing stays
+	/// a permanent cache hit — only the analytic glow layer moves.
+	let turbidity: Int
 }
 
-private let meshCache = SkyRenderCache<SkyMeshKey, (gradient: MeshGradient, stops: [Color])>(capacity: 64)
-private let glowCache = SkyRenderCache<Int, [Gradient.Stop]>(capacity: 64)
+private struct SkyGlowKey: Hashable {
+	let altitude: Int
+	let turbidity: Int
+}
+
+private let meshCache = SkyRenderCache<SkyMeshKey, (gradient: MeshGradient, stops: [Color])>(capacity: 128)
+private let glowCache = SkyRenderCache<SkyGlowKey, [Gradient.Stop]>(capacity: 128)
 
 private struct SkyDialKey: Hashable {
 	let startOfDay: Date
@@ -648,20 +709,24 @@ extension SkyModel {
 	/// for the horizon — and the mesh renders from the quantised values, so hits and misses agree
 	/// exactly. The glow anchor isn't an input at all: during a scrub the base sky is a permanent
 	/// cache hit while only the analytic glow layer moves.
-	func cachedMesh(sunAltitudeDeg: Double, horizonFraction: Double?) -> (gradient: MeshGradient, stops: [Color]) {
+	func cachedMesh(sunAltitudeDeg: Double, horizonFraction: Double?, turbidity: Double = 1.0) -> (gradient: MeshGradient, stops: [Color]) {
 		let key = SkyMeshKey(altitude: Int((sunAltitudeDeg * 10).rounded()),
-		                     horizon: horizonFraction.map { Int(($0 * 256).rounded()) })
+		                     horizon: horizonFraction.map { Int(($0 * 256).rounded()) },
+		                     turbidity: Int((turbidity * 50).rounded()))
 		return meshCache.value(for: key) {
-			mesh(sunAltitudeDeg: Double(key.altitude) / 10,
-			     horizonFraction: key.horizon.map { Double($0) / 256 })
+			adjusted(turbidity: Double(key.turbidity) / 50)
+				.mesh(sunAltitudeDeg: Double(key.altitude) / 10,
+				      horizonFraction: key.horizon.map { Double($0) / 256 })
 		}
 	}
 
-	/// Memoized `glowStops`, quantised to 0.1° of sun altitude.
-	func cachedGlowStops(sunAltitudeDeg: Double) -> [Gradient.Stop] {
-		let key = Int((sunAltitudeDeg * 10).rounded())
+	/// Memoized `glowStops`, quantised to 0.1° of sun altitude and ~0.02 of turbidity.
+	func cachedGlowStops(sunAltitudeDeg: Double, turbidity: Double = 1.0) -> [Gradient.Stop] {
+		let key = SkyGlowKey(altitude: Int((sunAltitudeDeg * 10).rounded()),
+		                     turbidity: Int((turbidity * 50).rounded()))
 		return glowCache.value(for: key) {
-			glowStops(sunAltitudeDeg: Double(key) / 10)
+			adjusted(turbidity: Double(key.turbidity) / 50)
+				.glowStops(sunAltitudeDeg: Double(key.altitude) / 10)
 		}
 	}
 
@@ -689,14 +754,17 @@ struct SkyView: View {
 	var sunAltitudeDeg: Double
 	var sunAnchor: UnitPoint? = nil
 	var horizonFraction: Double? = nil
+	/// Atmospheric turbidity for this sky. `1.0` is the neutral model; `SkyGradient` derives a
+	/// per-location, morning/evening value. The tuning previews leave it neutral.
+	var turbidity: Double = 1.0
 
 	var body: some View {
 		ZStack {
-			SkyModel.standard.cachedMesh(sunAltitudeDeg: sunAltitudeDeg, horizonFraction: horizonFraction).gradient
+			SkyModel.standard.cachedMesh(sunAltitudeDeg: sunAltitudeDeg, horizonFraction: horizonFraction, turbidity: turbidity).gradient
 
 			if let sunAnchor {
 				GeometryReader { geo in
-					RadialGradient(stops: SkyModel.standard.cachedGlowStops(sunAltitudeDeg: sunAltitudeDeg),
+					RadialGradient(stops: SkyModel.standard.cachedGlowStops(sunAltitudeDeg: sunAltitudeDeg, turbidity: turbidity),
 					               center: sunAnchor,
 					               startRadius: 0,
 					               endRadius: max(geo.size.width, geo.size.height))
@@ -771,14 +839,24 @@ struct SkyGradient: View, ShapeStyle {
 		return solar?.altitude(at: date) ?? 0
 	}
 
+	/// Atmospheric turbidity for this location and time of day: what makes a sunset read oranger
+	/// than a sunrise and varies the sky by latitude. Ambient surfaces with no real location
+	/// (widgets, the landing view) fall back through `effectiveSolar` to `.proxiedToTimeZone`
+	/// (latitude 0), so they get the tropical baseline plus the morning/evening term.
+	private var turbidity: Double {
+		guard let solar = effectiveSolar else { return 1.0 }
+		return SkyModel.turbidity(latitude: solar.coordinate.latitude,
+		                          ascending: solar.isAscending(at: solar.date))
+	}
+
 	/// The vertical colour ramp; `first` is the sky/zenith, `last` the horizon.
 	/// Consumed by `ShareSolarChartView` for the Instagram story background colours.
 	var stops: [Color] {
-		SkyModel.standard.cachedMesh(sunAltitudeDeg: sunAltitudeDeg, horizonFraction: horizonFraction).stops
+		SkyModel.standard.cachedMesh(sunAltitudeDeg: sunAltitudeDeg, horizonFraction: horizonFraction, turbidity: turbidity).stops
 	}
 
 	var body: some View {
-		SkyView(sunAltitudeDeg: sunAltitudeDeg, sunAnchor: sunAnchor, horizonFraction: horizonFraction)
+		SkyView(sunAltitudeDeg: sunAltitudeDeg, sunAnchor: sunAnchor, horizonFraction: horizonFraction, turbidity: turbidity)
 	}
 }
 

--- a/Solstice/Helpers/NTSolar.swift
+++ b/Solstice/Helpers/NTSolar.swift
@@ -703,19 +703,18 @@ struct NTSolar {
 }
 
 extension NTSolar {
-	/// Returns the sun's altitude above the horizon in degrees at the given instant.
-	/// Positive values are above the horizon, negative values are below.
+	/// The sun's position at a given instant: altitude above the horizon and local hour angle,
+	/// both in degrees. Shared by `altitude(at:)` and `hourAngle(at:)` so they never diverge.
 	///
-	/// Uses the same astronomical algorithms as the rest of NTSolar (Schlyter's
-	/// method), so results are consistent with the sunrise/sunset times already
-	/// computed by this struct.
-	func altitude(at date: Date) -> Double {
+	/// Uses the same astronomical algorithms as the rest of NTSolar (Schlyter's method), so
+	/// results are consistent with the sunrise/sunset times already computed by this struct.
+	func solarPosition(at date: Date) -> (altitude: Double, hourAngle: Double) {
 		var utcCal = Calendar(identifier: .gregorian)
 		utcCal.timeZone = TimeZone(secondsFromGMT: 0)!
 		let comps = utcCal.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
 		guard let year = comps.year, let month = comps.month, let day = comps.day,
 		      let hour = comps.hour, let minute = comps.minute, let second = comps.second
-		else { return 0 }
+		else { return (0, 0) }
 
 		// UT as a decimal hour
 		let UT = Double(hour) + Double(minute) / 60.0 + Double(second) / 3600.0
@@ -729,12 +728,32 @@ extension NTSolar {
 		// Local Mean Sidereal Time in degrees: GMST0(d) + UT_in_degrees + longitude
 		let LMST = NTSolar.revolution(x: NTSolar.GMST0(d: d) + UT * 15.0 + coordinate.longitude)
 
-		// Local Hour Angle: how far the sun has moved past the meridian
-		let HA = LMST - sRA
+		// Local Hour Angle: how far the sun has moved past the meridian, reduced to ±180° so its
+		// sign is meaningful — negative before local solar noon (sun east, ascending), positive after.
+		let HA = NTSolar.rev180(x: LMST - sRA)
 
 		// Standard altitude formula: sin(alt) = sin(lat)sin(dec) + cos(lat)cos(dec)cos(HA)
 		let sin_alt = NTSolar.sind(x: coordinate.latitude) * NTSolar.sind(x: sdec)
 			+ NTSolar.cosd(x: coordinate.latitude) * NTSolar.cosd(x: sdec) * NTSolar.cosd(x: HA)
-		return NTSolar.asind(x: sin_alt)
+		return (NTSolar.asind(x: sin_alt), HA)
+	}
+
+	/// Returns the sun's altitude above the horizon in degrees at the given instant.
+	/// Positive values are above the horizon, negative values are below.
+	func altitude(at date: Date) -> Double {
+		solarPosition(at: date).altitude
+	}
+
+	/// Local hour angle in degrees, reduced to ±180°: how far the sun sits from the local meridian.
+	/// Negative before local solar noon (sun to the east), positive after (sun to the west).
+	func hourAngle(at date: Date) -> Double {
+		solarPosition(at: date).hourAngle
+	}
+
+	/// Whether the sun is climbing toward its local noon (morning) rather than descending toward
+	/// night (afternoon). Derived from the hour angle's sign, so it stays defined even during polar
+	/// day/night when there is no sunrise or sunset event to compare against.
+	func isAscending(at date: Date) -> Bool {
+		hourAngle(at: date) < 0
 	}
 }

--- a/SolsticeTests/SkyModelTests.swift
+++ b/SolsticeTests/SkyModelTests.swift
@@ -202,4 +202,93 @@ struct SkyModelTests {
 			}
 		}
 	}
+
+	// MARK: - Turbidity, sunrise/sunset asymmetry, per-location variation
+
+	/// Warm-to-cool ratio of a near-horizon sky looking straight at the sun.
+	private func redToBlue(_ model: SkyModel) -> Double {
+		let rgb = model.radiance(sunAltitudeDeg: 1, viewElevationDeg: 2, scatterCosTheta: 1)
+		return rgb.x / max(rgb.z, 1e-12)
+	}
+
+	private func blueShare(_ model: SkyModel) -> Double {
+		let rgb = model.radiance(sunAltitudeDeg: 1, viewElevationDeg: 2, scatterCosTheta: 1)
+		return rgb.z / max(rgb.x + rgb.y + rgb.z, 1e-12)
+	}
+
+	@Test("Neutral turbidity reproduces the standard model exactly")
+	func neutralTurbidityIsIdentity() {
+		let neutral = model.adjusted(turbidity: 1.0)
+		for sunAltitude in [-10.0, 1, 20, 60] {
+			for cosTheta in [-1.0, 0, 0.5, 1] {
+				let base = model.radiance(sunAltitudeDeg: sunAltitude, viewElevationDeg: 10, scatterCosTheta: cosTheta)
+				let same = neutral.radiance(sunAltitudeDeg: sunAltitude, viewElevationDeg: 10, scatterCosTheta: cosTheta)
+				#expect(base == same)
+			}
+		}
+		// The default-argument cached path must stay neutral too, so existing renders are unchanged.
+		#expect(model.cachedMesh(sunAltitudeDeg: 12, horizonFraction: nil).stops
+			== model.cachedMesh(sunAltitudeDeg: 12, horizonFraction: nil, turbidity: 1.0).stops)
+	}
+
+	@Test("A setting sun is warmer than a rising sun at the same altitude and place")
+	func sunsetWarmerThanSunrise() {
+		let latitude = 40.0
+		let morning = model.adjusted(turbidity: SkyModel.turbidity(latitude: latitude, ascending: true))
+		let evening = model.adjusted(turbidity: SkyModel.turbidity(latitude: latitude, ascending: false))
+
+		// The whole point: they are no longer identical.
+		let morningRGB = morning.radiance(sunAltitudeDeg: 1, viewElevationDeg: 2, scatterCosTheta: 1)
+		let eveningRGB = evening.radiance(sunAltitudeDeg: 1, viewElevationDeg: 2, scatterCosTheta: 1)
+		#expect(morningRGB != eveningRGB)
+
+		// Evening reads oranger, morning cooler/pinker.
+		#expect(redToBlue(evening) > redToBlue(morning))
+		#expect(blueShare(morning) > blueShare(evening))
+	}
+
+	@Test("Turbidity varies with latitude")
+	func turbidityVariesWithLatitude() {
+		let tropics = SkyModel.turbidity(latitude: 0, ascending: false)
+		let temperate = SkyModel.turbidity(latitude: 60, ascending: false)
+		#expect(tropics != temperate)
+		// Hazier tropics ⇒ warmer near-horizon sky than the crisper high-latitude sky.
+		#expect(redToBlue(model.adjusted(turbidity: tropics)) > redToBlue(model.adjusted(turbidity: temperate)))
+	}
+
+	@Test("Hour angle reveals morning versus afternoon")
+	func hourAngleTracksTimeOfDay() throws {
+		let morning = try londonSolar(hour: 8)
+		let afternoon = try londonSolar(hour: 16)
+		#expect(morning.hourAngle(at: morning.date) < 0)
+		#expect(morning.isAscending(at: morning.date))
+		#expect(afternoon.hourAngle(at: afternoon.date) > 0)
+		#expect(!afternoon.isAscending(at: afternoon.date))
+	}
+
+	@Test("Turbidity is clamped so the sky never turns garish")
+	func turbidityClamps() {
+		#expect(model.adjusted(turbidity: 0.2).mie == model.mie * 0.80)
+		#expect(model.adjusted(turbidity: 5.0).mie == model.mie * 1.25)
+		for turbidity in [0.2, 5.0] {
+			let clamped = model.adjusted(turbidity: turbidity)
+			for cosTheta in stride(from: -1.0, through: 1, by: 0.5) {
+				let rgb = clamped.radiance(sunAltitudeDeg: 1, viewElevationDeg: 2, scatterCosTheta: cosTheta)
+				#expect(rgb.x.isFinite && rgb.y.isFinite && rgb.z.isFinite)
+				#expect(rgb.x >= 0 && rgb.y >= 0 && rgb.z >= 0)
+			}
+		}
+	}
+
+	@Test("Cached mesh honours turbidity: same quantised value hits, different values differ")
+	func cachedMeshHonoursTurbidity() {
+		// 1.16 quantises to itself (1.16 × 50 = 58), so the cache renders from exactly this value.
+		let cached = model.cachedMesh(sunAltitudeDeg: 2, horizonFraction: nil, turbidity: 1.16)
+		let direct = model.adjusted(turbidity: 1.16).mesh(sunAltitudeDeg: 2, horizonFraction: nil)
+		#expect(cached.stops == direct.stops)
+
+		// Distinct turbidity must not collide in the cache.
+		let neutral = model.cachedMesh(sunAltitudeDeg: 2, horizonFraction: nil, turbidity: 1.0)
+		#expect(neutral.stops != cached.stops)
+	}
 }


### PR DESCRIPTION
The physics sky model derived every colour purely from |sun altitude|, so a
sunrise and a sunset at the same altitude were byte-for-byte identical and every
location shared one sky. Real dawns skew pink and dusks skew orange, and the
effect varies by place.

Introduce a dimensionless turbidity scalar (aerosol load) that morning/evening
and latitude select, threaded through the existing single-scatter model:

- SkyModel.adjusted(turbidity:) returns a tuned copy — turbidity 1.0 is the
  identity, so all existing altitude-only behaviour is preserved exactly. It
  scales the Mie terms and nudges ozone: more aerosol adds a warm forward glow
  that arrives reddened (blue already lost along the long near-horizon path), so
  evenings read oranger; less aerosol lets the Rayleigh pink and ozone violet
  show through for cooler mornings. Clamped so it never turns garish.
- SkyModel.turbidity(latitude:ascending:) derives the value from the only cheap
  signals available: a climate term (hazier tropics, crisper poles) and a
  diurnal term (cleaner mornings, hazier evenings). No new data sources.
- NTSolar gains solarPosition(at:)/hourAngle(at:)/isAscending(at:), surfacing
  the local hour angle that altitude(at:) already computed and discarded, to
  tell morning from evening (robust in polar day/night). Geometry is unchanged;
  morning/evening only selects the turbidity value.
- Thread turbidity through cachedMesh/cachedGlowStops (cache keys gain a coarse
  turbidity bucket), SkyView, SkyGradient, and per-sample in dialStops so the
  dial's morning arc is cooler and its evening arc warmer.

Add tests: neutral turbidity is the identity, a setting sun is warmer than a
rising one at equal altitude/place, turbidity varies with latitude, hour angle
tracks time of day, clamping holds, and the mesh cache honours turbidity.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TcV6zPzTaKhetE5XhbsP38