### PR TITLE
fix(iOS): anchor the focus halo to a reference view instead of a frozen rect

### DIFF
--- a/Solstice/Helper Views/FocusHaloShape.swift
+++ b/Solstice/Helper Views/FocusHaloShape.swift
@@ -30,14 +30,14 @@
 			var cornerRadius: CGFloat = 0 {
 				didSet {
 					guard cornerRadius != oldValue else { return }
-					appliedHaloRect = .null
+					appliedBounds = .null
 					if let cell = enclosingCell { applyHaloIfNeeded(to: cell) }
 				}
 			}
 
 			private weak var hookedCell: UICollectionViewCell?
 			private weak var appliedCell: UICollectionViewCell?
-			private var appliedHaloRect: CGRect = .null
+			private var appliedBounds: CGRect = .null
 
 			convenience init(cornerRadius: CGFloat) {
 				self.init(frame: .zero)
@@ -52,12 +52,10 @@
 				applyHaloIfNeeded(to: cell)
 			}
 
-			/// The row content can move within the cell without this view laying
-			/// out again (position-only changes don't call `layoutSubviews`), which
-			/// left the halo at a stale offset — seen on the current-location row,
-			/// which is inserted late and settles after the first layout pass.
-			/// Focus and selection are configuration states, so recomputing here
-			/// refreshes the rect with settled geometry right when the halo shows.
+			/// The list rebuilds a reused cell's focus effect when it's
+			/// reconfigured, so — following the `ListRowPlatterRadius` pattern —
+			/// chain the cell's `configurationUpdateHandler` to reinstall the halo
+			/// after the system rebuilds the cell for a new row.
 			private func hookConfigurationUpdates(on cell: UICollectionViewCell) {
 				guard cell !== hookedCell else { return }
 				hookedCell = cell
@@ -69,19 +67,30 @@
 				}
 			}
 
+			/// Anchors the halo to this view via `referenceView` instead of
+			/// freezing a rect converted into cell coordinates. UIKit then resolves
+			/// the halo geometry from this view live, so the ring stays aligned even
+			/// when the row content moves within the cell after the effect is
+			/// installed — the case the current-location row hit on first launch,
+			/// where it's inserted late (after authorization resolves) and settles
+			/// with a position-only move that never lays this view out again. The
+			/// frozen rect was captured before that settle and left the ring
+			/// offset until an unrelated focus change recomputed it.
 			private func applyHaloIfNeeded(to cell: UICollectionViewCell) {
 				guard bounds.width > 0, bounds.height > 0 else { return }
-				let haloRect = cell.convert(bounds, from: self)
-				// Reassigning the effect invalidates layout, so only assign when
-				// the geometry actually changes to avoid a layout/focus loop.
-				guard haloRect != appliedHaloRect || cell !== appliedCell else { return }
-				appliedHaloRect = haloRect
+				// Reassigning the effect invalidates layout, so only assign when the
+				// size or target cell changes to avoid a layout/focus loop; the
+				// reference view tracks position changes without reassignment.
+				guard bounds != appliedBounds || cell !== appliedCell else { return }
+				appliedBounds = bounds
 				appliedCell = cell
-				cell.focusEffect = UIFocusHaloEffect(
-					roundedRect: haloRect,
+				let effect = UIFocusHaloEffect(
+					roundedRect: bounds,
 					cornerRadius: cornerRadius,
 					curve: .continuous
 				)
+				effect.referenceView = self
+				cell.focusEffect = effect
 			}
 
 			private var enclosingCell: UICollectionViewCell? {


### PR DESCRIPTION
The previous fix recomputed the halo rect on the cell's configuration
updates, but the current-location row still showed a misplaced ring on
first launch: it's inserted late (after authorization resolves) and settles
into position with a move that never lays the halo view out again, so the
rect captured for the first focus — converted into cell coordinates — was
stale. Only an unrelated focus change recomputed it, which is why leaving
the cell and returning corrected the ring.

Follow the WWDC21 pattern of setting UIFocusHaloEffect.referenceView to the
halo view and passing its own bounds, so UIKit resolves the halo geometry
from the live view at render time. Position changes within the cell are then
tracked automatically without reassigning the effect, and the ring lands
correctly on the first render.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LTxWjyZALruT7v5FM8BGcg