### PR TITLE
feat(lunar): add a solar/lunar/both mode to the detail view

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -14701,6 +14701,818 @@
           }
         }
       }
+    },
+    "Sun" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "الشمس"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Sonne"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Sol"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Soleil"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Sole"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "太陽"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Zon"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Słońce"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "太阳"
+          }
+        }
+      }
+    },
+    "Moon" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "القمر"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Mond"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Luna"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Lune"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Luna"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Maan"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Księżyc"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "月亮"
+          }
+        }
+      }
+    },
+    "Sun and moon" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "الشمس والقمر"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Sonne und Mond"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Sol y Luna"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Soleil et Lune"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Sole e Luna"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "太陽と月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Zon en maan"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Słońce i Księżyc"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "太阳和月亮"
+          }
+        }
+      }
+    },
+    "Show" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "إظهار"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Anzeigen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Mostrar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Afficher"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Mostra"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "表示"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Toon"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Pokaż"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "显示"
+          }
+        }
+      }
+    },
+    "New moon" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "محاق"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Neumond"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Luna nueva"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Nouvelle lune"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Luna nuova"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "新月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Nieuwe maan"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Nów"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "新月"
+          }
+        }
+      }
+    },
+    "Waxing crescent" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "هلال متزايد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Zunehmende Sichel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Luna creciente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Premier croissant"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Luna crescente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "三日月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Wassende maansikkel"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Sierp przybywający"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "蛾眉月"
+          }
+        }
+      }
+    },
+    "First quarter" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "التربيع الأول"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Erstes Viertel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Cuarto creciente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Premier quartier"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Primo quarto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "上弦の月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Eerste kwartier"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Pierwsza kwadra"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "上弦月"
+          }
+        }
+      }
+    },
+    "Waxing gibbous" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "أحدب متزايد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Zunehmender Mond"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Gibosa creciente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Gibbeuse croissante"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Gibbosa crescente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "十三夜月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Wassende maan"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Garb przybywający"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "盈凸月"
+          }
+        }
+      }
+    },
+    "Full moon" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "بدر"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Vollmond"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Luna llena"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Pleine lune"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Luna piena"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "満月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Volle maan"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Pełnia"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "满月"
+          }
+        }
+      }
+    },
+    "Waning gibbous" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "أحدب متناقص"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Abnehmender Mond"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Gibosa menguante"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Gibbeuse décroissante"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Gibbosa calante"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "寝待月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Afnemende maan"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Garb ubywający"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "亏凸月"
+          }
+        }
+      }
+    },
+    "Last quarter" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "التربيع الأخير"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Letztes Viertel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Cuarto menguante"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Dernier quartier"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Ultimo quarto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "下弦の月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Laatste kwartier"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Ostatnia kwadra"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "下弦月"
+          }
+        }
+      }
+    },
+    "Waning crescent" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "هلال متناقص"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Abnehmende Sichel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Luna menguante"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Dernier croissant"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Luna calante"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "有明月"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Afnemende maansikkel"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Sierp ubywający"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "残月"
+          }
+        }
+      }
+    },
+    "Moonrise" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "شروق القمر"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Mondaufgang"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Salida de la Luna"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Lever de la Lune"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Sorgere della Luna"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "月の出"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Maansopkomst"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Wschód Księżyca"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "月出"
+          }
+        }
+      }
+    },
+    "Moonset" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "غروب القمر"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Monduntergang"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Puesta de la Luna"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Coucher de la Lune"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Tramonto della Luna"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "月の入り"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Maansondergang"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Zachód Księżyca"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "月落"
+          }
+        }
+      }
     }
   },
   "version" : "1.3"

--- a/Solstice.xcodeproj/project.pbxproj
+++ b/Solstice.xcodeproj/project.pbxproj
@@ -98,6 +98,18 @@
 		71EC11FE2F30000000000012 /* EclipseCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000001 /* EclipseCalculator.swift */; };
 		71EC11FE2F30000000000013 /* EclipseCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000001 /* EclipseCalculator.swift */; };
 		71EC11FE2F30000000000014 /* EclipseCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000001 /* EclipseCalculator.swift */; };
+		71EC11FE2F30000000000111 /* Ephemeris.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000101 /* Ephemeris.swift */; };
+		71EC11FE2F30000000000112 /* Ephemeris.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000101 /* Ephemeris.swift */; };
+		71EC11FE2F30000000000113 /* Ephemeris.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000101 /* Ephemeris.swift */; };
+		71EC11FE2F30000000000114 /* Ephemeris.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000101 /* Ephemeris.swift */; };
+		71EC11FE2F30000000000121 /* LunarCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000102 /* LunarCalculator.swift */; };
+		71EC11FE2F30000000000122 /* LunarCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000102 /* LunarCalculator.swift */; };
+		71EC11FE2F30000000000123 /* LunarCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000102 /* LunarCalculator.swift */; };
+		71EC11FE2F30000000000124 /* LunarCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000102 /* LunarCalculator.swift */; };
+		71EC11FE2F30000000000131 /* LunarCalculator++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000103 /* LunarCalculator++.swift */; };
+		71EC11FE2F30000000000132 /* LunarCalculator++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000103 /* LunarCalculator++.swift */; };
+		71EC11FE2F30000000000133 /* LunarCalculator++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000103 /* LunarCalculator++.swift */; };
+		71EC11FE2F30000000000134 /* LunarCalculator++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000103 /* LunarCalculator++.swift */; };
 		71EC11FE2F30000000000021 /* EclipseOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000002 /* EclipseOverview.swift */; };
 		71EC11FE2F30000000000022 /* EclipseOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EC11FE2F30000000000002 /* EclipseOverview.swift */; };
 		713F7FFD29BE867E00BEA156 /* DailyOverview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713F7FFB29BE867E00BEA156 /* DailyOverview.swift */; };
@@ -522,6 +534,9 @@
 		71C718202E83361C006A6835 /* TimeTravelCompactView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTravelCompactView.swift; sourceTree = "<group>"; };
 		71C8F4CD29A38752009A86B4 /* SolsticeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolsticeCalculator.swift; sourceTree = "<group>"; };
 		71EC11FE2F30000000000001 /* EclipseCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EclipseCalculator.swift; sourceTree = "<group>"; };
+		71EC11FE2F30000000000101 /* Ephemeris.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ephemeris.swift; sourceTree = "<group>"; };
+		71EC11FE2F30000000000102 /* LunarCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunarCalculator.swift; sourceTree = "<group>"; };
+		71EC11FE2F30000000000103 /* LunarCalculator++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunarCalculator++.swift; sourceTree = "<group>"; };
 		71EC11FE2F30000000000002 /* EclipseOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EclipseOverview.swift; sourceTree = "<group>"; };
 		71CA1E0029E0000000000001 /* Calendar++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar++.swift"; sourceTree = "<group>"; };
 		71CCE7993022311F00E2782D /* TimeTravelOrnamentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTravelOrnamentView.swift; sourceTree = "<group>"; };
@@ -833,6 +848,8 @@
 				BE27E44FFAA0D1493AA14281 /* Secrets.swift.template */,
 				71E9457F2F31FDA600B26D02 /* NTSolar.swift */,
 				71EC11FE2F30000000000001 /* EclipseCalculator.swift */,
+				71EC11FE2F30000000000101 /* Ephemeris.swift */,
+				71EC11FE2F30000000000102 /* LunarCalculator.swift */,
 				71C8F4CD29A38752009A86B4 /* SolsticeCalculator.swift */,
 				71908ACC2AC95A5500C7B610 /* StringBuilder.swift */,
 				7123E75E30052CE20091C591 /* ScreenshotSupport.swift */,
@@ -854,6 +871,7 @@
 				712433922D77A4CE00709C20 /* EdgeInsets++.swift */,
 				712433AA2D79090100709C20 /* NSImage+pngData.swift */,
 				71E9459D2F32095300B26D02 /* NTSolar++.swift */,
+				71EC11FE2F30000000000103 /* LunarCalculator++.swift */,
 				71F641BC299968BF00FE5AB5 /* TimeInterval++.swift */,
 				71C105A32E7D311700A76EBB /* TimeMachine++.swift */,
 				7195125729B48ECD009D282F /* TimeZone++.swift */,
@@ -1241,12 +1259,15 @@
 				7187147729DDE6B700EADF03 /* CLLocationCoordinate2D++.swift in Sources */,
 				7150CC5C29AB7C3200E6B90C /* SolsticeCalculator.swift in Sources */,
 				71EC11FE2F30000000000011 /* EclipseCalculator.swift in Sources */,
+				71EC11FE2F30000000000111 /* Ephemeris.swift in Sources */,
+				71EC11FE2F30000000000121 /* LunarCalculator.swift in Sources */,
 				7121DE0229C22E7D0031EEE7 /* View+Debugging.swift in Sources */,
 				7198C40E29DB06C1009A457E /* OverviewWidget.swift in Sources */,
 				718177692F2EA2EC007A2E9E /* LocationAppEntity.swift in Sources */,
 				719465172C294B42008408C0 /* Color+Mix.swift in Sources */,
 				7107208B300919ED006AA79C /* SeedState.swift in Sources */,
 				71E9459F2F32095300B26D02 /* NTSolar++.swift in Sources */,
+				71EC11FE2F30000000000131 /* LunarCalculator++.swift in Sources */,
 				715489B52F201D8400FD5CCE /* SolsticeWidgetLocationManager.swift in Sources */,
 				719F557D29DB1A4300D7AE8E /* CountdownWidgetView+AccessoryWidgetViews.swift in Sources */,
 				7106C88429A2775C0007A7EC /* TimeInterval++.swift in Sources */,
@@ -1318,6 +1339,8 @@
 				719465242C2C1E09008408C0 /* CLLocationCoordinate2D++.swift in Sources */,
 				719465252C2C1E09008408C0 /* SolsticeCalculator.swift in Sources */,
 				71EC11FE2F30000000000012 /* EclipseCalculator.swift in Sources */,
+				71EC11FE2F30000000000112 /* Ephemeris.swift in Sources */,
+				71EC11FE2F30000000000122 /* LunarCalculator.swift in Sources */,
 				719465262C2C1E09008408C0 /* View+Debugging.swift in Sources */,
 				719465272C2C1E09008408C0 /* OverviewWidget.swift in Sources */,
 				719465282C2C1E09008408C0 /* Color+Mix.swift in Sources */,
@@ -1354,6 +1377,7 @@
 				719465402C2C1E09008408C0 /* Date++.swift in Sources */,
 				71CA1E0029E0000000000003 /* Calendar++.swift in Sources */,
 				71E945A32F32095300B26D02 /* NTSolar++.swift in Sources */,
+				71EC11FE2F30000000000132 /* LunarCalculator++.swift in Sources */,
 				71C105A52E7D311B00A76EBB /* TimeMachine++.swift in Sources */,
 				719465422C2C1E09008408C0 /* View+RectangularEdgeMask.swift in Sources */,
 				715489B42F201D8400FD5CCE /* SolsticeWidgetLocationManager.swift in Sources */,
@@ -1414,6 +1438,7 @@
 				7116B1EA2DDD07F70018A294 /* View+timeMachineOverlayModifier.swift in Sources */,
 				7107208F3009257E006AA79C /* MarketingWidgetRenderer.swift in Sources */,
 				71E945A02F32095300B26D02 /* NTSolar++.swift in Sources */,
+				71EC11FE2F30000000000133 /* LunarCalculator++.swift in Sources */,
 				71F641C3299FD39E00FE5AB5 /* View+CapsuleAppearance.swift in Sources */,
 				7132AC1929E6962D00523215 /* ConditionalGlobals.swift in Sources */,
 				711782D82E4DFDFE0006CE5B /* DeduplicateLocationRecordsModifier.swift in Sources */,
@@ -1421,6 +1446,8 @@
 				71BC51CB2E91B56D0025892F /* CircularSolarChart.swift in Sources */,
 				71C8F4CE29A38752009A86B4 /* SolsticeCalculator.swift in Sources */,
 				71EC11FE2F30000000000013 /* EclipseCalculator.swift in Sources */,
+				71EC11FE2F30000000000113 /* Ephemeris.swift in Sources */,
+				71EC11FE2F30000000000123 /* LunarCalculator.swift in Sources */,
 				711782EA2E4E7CE20006CE5B /* AsyncButton.swift in Sources */,
 				7116B1EE2DDD12BA0018A294 /* TimeMachinePanelView.swift in Sources */,
 				718177622F2E9BCF007A2E9E /* SolsticeConfigurationIntent.swift in Sources */,
@@ -1520,6 +1547,8 @@
 				71E945C82F32506000B26D02 /* CircularSolarChart.swift in Sources */,
 				719F927C29ACD22100C06921 /* SolsticeCalculator.swift in Sources */,
 				71EC11FE2F30000000000014 /* EclipseCalculator.swift in Sources */,
+				71EC11FE2F30000000000114 /* Ephemeris.swift in Sources */,
+				71EC11FE2F30000000000124 /* LunarCalculator.swift in Sources */,
 				719465162C294B42008408C0 /* Color+Mix.swift in Sources */,
 				71E3C41B2EA12B030005C884 /* View+backportGlassEffect.swift in Sources */,
 				7194650F2C22B61E008408C0 /* AppChangeMigrator.swift in Sources */,
@@ -1536,6 +1565,7 @@
 				712433952D77A4CE00709C20 /* EdgeInsets++.swift in Sources */,
 				712433AB2D79090500709C20 /* NSImage+pngData.swift in Sources */,
 				71E945A12F32095300B26D02 /* NTSolar++.swift in Sources */,
+				71EC11FE2F30000000000134 /* LunarCalculator++.swift in Sources */,
 				7116B1F62DDDE2130018A294 /* VariableBlurView.swift in Sources */,
 				713F7FFD29BE867E00BEA156 /* DailyOverview.swift in Sources */,
 				718177672F2EA2EC007A2E9E /* LocationAppEntity.swift in Sources */,

--- a/Solstice.xcodeproj/project.pbxproj
+++ b/Solstice.xcodeproj/project.pbxproj
@@ -536,7 +536,7 @@
 		71EC11FE2F30000000000001 /* EclipseCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EclipseCalculator.swift; sourceTree = "<group>"; };
 		71EC11FE2F30000000000101 /* Ephemeris.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ephemeris.swift; sourceTree = "<group>"; };
 		71EC11FE2F30000000000102 /* LunarCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunarCalculator.swift; sourceTree = "<group>"; };
-		71EC11FE2F30000000000103 /* LunarCalculator++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunarCalculator++.swift; sourceTree = "<group>"; };
+		71EC11FE2F30000000000103 /* LunarCalculator++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LunarCalculator++.swift"; sourceTree = "<group>"; };
 		71EC11FE2F30000000000002 /* EclipseOverview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EclipseOverview.swift; sourceTree = "<group>"; };
 		71CA1E0029E0000000000001 /* Calendar++.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar++.swift"; sourceTree = "<group>"; };
 		71CCE7993022311F00E2782D /* TimeTravelOrnamentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTravelOrnamentView.swift; sourceTree = "<group>"; };

--- a/Solstice/Charts/DaylightChart.swift
+++ b/Solstice/Charts/DaylightChart.swift
@@ -14,6 +14,7 @@ struct DaylightChart: View {
 	@Environment(\.isLuminanceReduced) var isLuminanceReduced
 	@Environment(\.colorScheme) var colorScheme
 	@Environment(\.timeMachine) private var timeMachine
+	@AppStorage(Preferences.bodyMode) var bodyMode
 
 	@State private var selectedEvent: NTSolar.Event?
 	@State private var currentX: TimeInterval?
@@ -110,18 +111,41 @@ struct DaylightChart: View {
 		Chart {
 			let hours = hours
 			let altitudes = sampledAltitudes
-			ForEach(hours.indices, id: \.self) { index in
-				LineMark(
-					x: .value("Time", hours[index]),
-					y: .value("Altitude", altitudes[index])
-				)
-				.interpolationMethod(.catmullRom)
-				.foregroundStyle(solarPathGradient)
-				.lineStyle(StrokeStyle(lineWidth: markSize, lineCap: .round, lineJoin: .round))
+
+			// The moon goes down first so the sun's path draws over it where they cross.
+			if let moonAltitudes = sampledMoonAltitudes {
+				ForEach(hours.indices, id: \.self) { index in
+					LineMark(
+						x: .value("Time", hours[index]),
+						y: .value("Moon altitude", moonAltitudes[index]),
+						series: .value("Body", "moon")
+					)
+					.interpolationMethod(.catmullRom)
+					.foregroundStyle(.secondary)
+					.lineStyle(StrokeStyle(
+						lineWidth: max(1, markSize / 2),
+						lineCap: .round,
+						lineJoin: .round,
+						dash: [markSize / 2, markSize]
+					))
+				}
 			}
 
-			ForEach(filteredEvents, id: \.id) { solarEvent in
-				eventPointMark(for: solarEvent)
+			if bodyMode.includesSun {
+				ForEach(hours.indices, id: \.self) { index in
+					LineMark(
+						x: .value("Time", hours[index]),
+						y: .value("Altitude", altitudes[index]),
+						series: .value("Body", "sun")
+					)
+					.interpolationMethod(.catmullRom)
+					.foregroundStyle(solarPathGradient)
+					.lineStyle(StrokeStyle(lineWidth: markSize, lineCap: .round, lineJoin: .round))
+				}
+
+				ForEach(filteredEvents, id: \.id) { solarEvent in
+					eventPointMark(for: solarEvent)
+				}
 			}
 		}
 		.chartLegend(.hidden)
@@ -423,7 +447,13 @@ extension DaylightChart {
 	/// Callers may override via the `yScale` property.
 	private var effectiveYScale: ClosedRange<Double> {
 		if let yScale { return yScale }
-		let altitudes = sampledAltitudes
+
+		// Fit to whichever bodies are actually drawn. In lunar mode the sun's path isn't
+		// on screen, so letting it set the scale would squash the moon into a corner.
+		var altitudes: [Double] = []
+		if bodyMode.includesSun { altitudes += sampledAltitudes }
+		if let moonAltitudes = sampledMoonAltitudes { altitudes += moonAltitudes }
+
 		guard let minAlt = altitudes.min(), let maxAlt = altitudes.max() else {
 			return -90.0 ... 90.0
 		}
@@ -446,6 +476,29 @@ extension DaylightChart {
 		                             longitude: Int((solar.coordinate.longitude * 1e4).rounded()))
 		return altitudeSamplesCache.value(for: key) {
 			hours.map { yValue(for: $0) }
+		}
+	}
+
+	/// The moon's altitude for every sampled hour, or `nil` when the moon isn't plotted.
+	///
+	/// Memoized the same way the sun's samples are, and for the same reason. Note this is
+	/// a computed property rather than `@State` filled by `.task`: the share card renders
+	/// this chart through `ImageRenderer`, which never runs the view lifecycle, so
+	/// anything that depends on a task would come out blank there.
+	private var sampledMoonAltitudes: [Double]? {
+		guard bodyMode.includesMoon else { return nil }
+
+		let coordinate = solar.coordinate
+		let key = AltitudeSamplesKey(midnight: midnight,
+		                             latitude: Int((coordinate.latitude * 1e4).rounded()),
+		                             longitude: Int((coordinate.longitude * 1e4).rounded()))
+		return moonAltitudeSamplesCache.value(for: key) {
+			hours.map { offset in
+				LunarCalculator.altitude(
+					at: midnight.addingTimeInterval(offset),
+					coordinate: coordinate
+				)
+			}
 		}
 	}
 
@@ -482,6 +535,7 @@ private struct AltitudeSamplesKey: Hashable {
 }
 
 private let altitudeSamplesCache = SkyRenderCache<AltitudeSamplesKey, [Double]>(capacity: 16)
+private let moonAltitudeSamplesCache = SkyRenderCache<AltitudeSamplesKey, [Double]>(capacity: 16)
 
 extension DaylightChart {
 	enum Appearance: String, Codable, CaseIterable {

--- a/Solstice/Charts/DaylightChart.swift
+++ b/Solstice/Charts/DaylightChart.swift
@@ -29,6 +29,9 @@ struct DaylightChart: View {
 	}
 
 	var solar: NTSolar
+	/// Supplied by `DailyOverview`, which already computes it. Only needed for the phase
+	/// glyph — the moon's path is sampled from `solar.coordinate`.
+	var moon: LunarCalculator.Moon? = nil
 	var timeZone: TimeZone
 	var showEventTypes = true
 
@@ -123,7 +126,7 @@ struct DaylightChart: View {
 					.interpolationMethod(.catmullRom)
 					.foregroundStyle(.secondary)
 					.lineStyle(StrokeStyle(
-						lineWidth: max(1, markSize / 2),
+						lineWidth: max(1, markSize / 3),
 						lineCap: .round,
 						lineJoin: .round,
 						dash: [markSize / 2, markSize]
@@ -239,6 +242,7 @@ struct DaylightChart: View {
 			scrubIndicator(proxy: proxy, geoHeight: geo.size.height)
 			sunBelowHorizon(proxy: proxy, geo: geo, horizonY: horizonY)
 			sunAboveHorizon(proxy: proxy, horizonY: horizonY)
+			moonMarker(proxy: proxy)
 		}
 
 		scrubHitArea(geo: geo, proxy: proxy)
@@ -267,8 +271,14 @@ struct DaylightChart: View {
 		let frame = geo.frame(in: .named(SkyGradient.coordinateSpaceName))
 		var geometry = SkyChartGeometry(date: midnight.addingTimeInterval(offset))
 
-		let position = sunPosition(for: offset, proxy: proxy)
-		geometry.sunPoint = CGPoint(x: frame.minX + position.x, y: frame.minY + position.y)
+		// Left unset in lunar mode. `sunPoint` becomes the SkyGradient's `sunAnchor`, so
+		// publishing it with no sun drawn would leave a bright highlight tracking an
+		// invisible marker. The sky keeps its day/night colouring either way — that comes
+		// from `date` and `horizonY`.
+		if bodyMode.includesSun {
+			let position = sunPosition(for: offset, proxy: proxy)
+			geometry.sunPoint = CGPoint(x: frame.minX + position.x, y: frame.minY + position.y)
+		}
 
 		if let horizonY = proxy.position(forY: 0.0) {
 			geometry.horizonY = frame.minY + horizonY
@@ -339,6 +349,9 @@ struct DaylightChart: View {
 				.position(sunPosition(for: offset, proxy: proxy))
 				.shadow(color: .secondary.opacity(0.5), radius: 2)
 				.blendMode(.normal)
+				// Hidden rather than skipped: the veil and mask below belong to the chart,
+				// not to the sun, and must survive in lunar mode.
+				.opacity(bodyMode.includesSun ? 1 : 0)
 		}
 		.background {
 			// In simple appearance the chart sits on a plain background, so a subtle veil marks the
@@ -368,10 +381,35 @@ struct DaylightChart: View {
 				.frame(width: markSize * 2.5, height: markSize * 2.5)
 				.position(sunPosition(for: offset, proxy: proxy))
 				.shadow(color: .secondary.opacity(0.5), radius: 3)
+				.opacity(bodyMode.includesSun ? 1 : 0)
 		}
 		.mask(alignment: .top) {
 			Rectangle()
 				.frame(height: horizonY)
+		}
+	}
+
+	/// The moon's phase glyph at the plotted moment.
+	///
+	/// Positioned directly rather than through `AlongSolarPath` — that exists to glide the
+	/// sun's marker during a scrub, and the moon doesn't need to carry that machinery.
+	@ViewBuilder
+	private func moonMarker(proxy: ChartProxy) -> some View {
+		if bodyMode.includesMoon, let moon {
+			let offset = plotOffset
+			let altitude = LunarCalculator.altitude(
+				at: midnight.addingTimeInterval(offset),
+				coordinate: solar.coordinate
+			)
+
+			Image(systemName: moon.phase.symbolName(latitude: solar.coordinate.latitude))
+				.font(.system(size: markSize * 2.5))
+				.foregroundStyle(markForegroundColor)
+				.shadow(color: .secondary.opacity(0.5), radius: 2)
+				.position(
+					x: proxy.position(forX: offset) ?? 0,
+					y: proxy.position(forY: altitude) ?? 0
+				)
 		}
 	}
 

--- a/Solstice/Detail View/DailyOverview.swift
+++ b/Solstice/Detail View/DailyOverview.swift
@@ -45,95 +45,105 @@ struct DailyOverview<Location: AnyLocation>: View {
 	}
 
 	var body: some View {
-		Section {
-			VStack {
-				switch chartType {
-				#if !os(watchOS)
-					case .circular:
-						CircularSolarChart(location: location)
-							.padding()
-							.frame(maxHeight: chartHeight)
-							.frame(maxWidth: .infinity)
-				#endif
-				default:
-					daylightChartView
-						.frame(height: chartHeight)
-						.environment(\.timeZone, location.timeZone)
-				}
-			}
-			.listRowInsets(.zero)
-			#if os(watchOS)
-				.listRowBackground(Color.clear)
-			#else
-				.contextMenu {
-					Picker(selection: $chartType.animation()) {
-						ForEach(ChartType.allCases) { chartType in
-							Label(chartType.title, image: chartType.icon)
-								.symbolRenderingMode(.hierarchical)
-								.imageScale(.large)
-								.labelStyle(.titleAndIcon)
-						}
-					} label: {
-						Text("Chart type")
+		// Two sections rather than one: the chart and the sun above, the moon below.
+		// Interleaving them made the two bodies’ times read as a single list.
+		Group {
+			Section {
+				VStack {
+					switch chartType {
+					#if !os(watchOS)
+						case .circular:
+							CircularSolarChart(location: location)
+								.padding()
+								.frame(maxHeight: chartHeight)
+								.frame(maxWidth: .infinity)
+					#endif
+					default:
+						daylightChartView
+							.frame(height: chartHeight)
+							.environment(\.timeZone, location.timeZone)
 					}
-					.pickerStyle(.menu)
-
-					Picker(selection: $chartAppearance.animation()) {
-						ForEach(DaylightChart.Appearance.allCases, id: \.self) { appearance in
-							Label(appearance.description, systemImage: "circle.fill")
-								.tint(appearance.tintColor.gradient)
-						}
-					} label: {
-						Text("Chart theme")
-					}
-					.pickerStyle(.menu)
 				}
-				.alignmentGuide(.listRowSeparatorLeading) { d in d[.leading] }
-				.alignmentGuide(.listRowSeparatorTrailing) { d in d[.trailing] }
-				#if !os(visionOS)
-					.listRowBackground(
-						solar.view
-							.opacity(chartType == .circular && chartAppearance == .graphical ? 0.3 : 0)
-							.mask {
-								LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
+				.listRowInsets(.zero)
+				#if os(watchOS)
+					.listRowBackground(Color.clear)
+				#else
+					.contextMenu {
+						Picker(selection: $chartType.animation()) {
+							ForEach(ChartType.allCases) { chartType in
+								Label(chartType.title, image: chartType.icon)
+									.symbolRenderingMode(.hierarchical)
+									.imageScale(.large)
+									.labelStyle(.titleAndIcon)
 							}
-							.background(Color("listRowBackgroundColor"))
-					)
+						} label: {
+							Text("Chart type")
+						}
+						.pickerStyle(.menu)
+
+						Picker(selection: $chartAppearance.animation()) {
+							ForEach(DaylightChart.Appearance.allCases, id: \.self) { appearance in
+								Label(appearance.description, systemImage: "circle.fill")
+									.tint(appearance.tintColor.gradient)
+							}
+						} label: {
+							Text("Chart theme")
+						}
+						.pickerStyle(.menu)
+					}
+					.alignmentGuide(.listRowSeparatorLeading) { d in d[.leading] }
+					.alignmentGuide(.listRowSeparatorTrailing) { d in d[.trailing] }
+					#if !os(visionOS)
+						.listRowBackground(
+							solar.view
+								.opacity(chartType == .circular && chartAppearance == .graphical ? 0.3 : 0)
+								.mask {
+									LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
+								}
+								.background(Color("listRowBackgroundColor"))
+						)
+					#endif
 				#endif
-			#endif
 
-			Group {
 				if bodyMode.includesSun {
-					solarRows
+					Group {
+						solarRows
+					}
+					.environment(\.timeZone, location.timeZone)
+					.materialListRowBackground()
 				}
+			} header: {
+				if location.timeZoneIdentifier != localTimeZone.identifier,
+				   !(location is CurrentLocation)
+				{
+					HStack {
+						Text("Local time")
+						Spacer()
+						Text("\(solar.date, style: .time) (\(location.timeZone.differenceStringFromLocalTime(for: timeMachine.date)))")
+					}
+					.environment(\.timeZone, location.timeZone)
+				}
+			} footer: {
+				if let differenceFromPreviousSolstice {
+					let moreOrLess = nextGreaterThanPrevious
+						? String(localized: "more", comment: "More daylight middle of sentence")
+						: String(localized: "less", comment: "Less daylight middle of sentence")
+					Label {
+						Text("\(Duration.seconds(abs(differenceFromPreviousSolstice)).formatted(.units(maximumUnitCount: 2))) \(moreOrLess) daylight \(timeMachine.dateLabel(context: .middleOfSentence)) compared to the previous solstice")
+					} icon: {
+						Image(systemName: nextGreaterThanPrevious ? "chart.line.uptrend.xyaxis" : "chart.line.downtrend.xyaxis")
+							.contentTransition(.symbolEffect)
+					}
+				}
+			}
 
-				if bodyMode.includesMoon, let moon {
-					lunarRows(for: moon)
-				}
-			}
-			.environment(\.timeZone, location.timeZone)
-			.materialListRowBackground()
-		} header: {
-			if location.timeZoneIdentifier != localTimeZone.identifier,
-			   !(location is CurrentLocation)
-			{
-				HStack {
-					Text("Local time")
-					Spacer()
-					Text("\(solar.date, style: .time) (\(location.timeZone.differenceStringFromLocalTime(for: timeMachine.date)))")
-				}
-				.environment(\.timeZone, location.timeZone)
-			}
-		} footer: {
-			if let differenceFromPreviousSolstice {
-				let moreOrLess = nextGreaterThanPrevious
-					? String(localized: "more", comment: "More daylight middle of sentence")
-					: String(localized: "less", comment: "Less daylight middle of sentence")
-				Label {
-					Text("\(Duration.seconds(abs(differenceFromPreviousSolstice)).formatted(.units(maximumUnitCount: 2))) \(moreOrLess) daylight \(timeMachine.dateLabel(context: .middleOfSentence)) compared to the previous solstice")
-				} icon: {
-					Image(systemName: nextGreaterThanPrevious ? "chart.line.uptrend.xyaxis" : "chart.line.downtrend.xyaxis")
-						.contentTransition(.symbolEffect)
+			if bodyMode.includesMoon, let moon {
+				Section {
+					Group {
+						lunarRows(for: moon)
+					}
+					.environment(\.timeZone, location.timeZone)
+					.materialListRowBackground()
 				}
 			}
 		}
@@ -229,8 +239,10 @@ struct DailyOverview<Location: AnyLocation>: View {
 				Text(moon.phase.localizedName)
 			}
 		} icon: {
+			// No `contentTransition` here: the glyph changes whenever the moon data
+			// arrives, which is on every day change, so the symbol effect fired far more
+			// often than it looked like it would.
 			Image(systemName: moon.phase.symbolName(latitude: location.latitude))
-				.contentTransition(.symbolEffect)
 		}
 
 		Label {
@@ -279,6 +291,7 @@ extension DailyOverview {
 	var daylightChartView: some View {
 		DaylightChart(
 			solar: solar,
+			moon: moon,
 			timeZone: location.timeZone,
 			appearance: chartAppearance, scrubbable: true,
 			markSize: chartMarkSize,

--- a/Solstice/Detail View/DailyOverview.swift
+++ b/Solstice/Detail View/DailyOverview.swift
@@ -17,6 +17,12 @@ struct DailyOverview<Location: AnyLocation>: View {
 
 	@AppStorage(Preferences.detailViewChartAppearance) private var chartAppearance
 	@AppStorage(Preferences.chartType) private var chartType
+	@AppStorage(Preferences.bodyMode) private var bodyMode
+
+	/// The moon for the displayed day, or `nil` while it is still being worked out.
+	/// Owned by `DetailView` so the search is cached rather than repeated on every body
+	/// evaluation.
+	var moon: LunarCalculator.Moon? = nil
 
 	var solarDateIsInToday: Bool {
 		var calendar = Calendar.autoupdatingCurrent
@@ -97,78 +103,12 @@ struct DailyOverview<Location: AnyLocation>: View {
 			#endif
 
 			Group {
-				Label {
-					AdaptiveStack {
-						Text(Duration.seconds(solar.daylightDuration).formatted(.units(maximumUnitCount: 2)))
-					} label: {
-						Text("Total daylight")
-					}
-				} icon: {
-					Image(systemName: "hourglass")
+				if bodyMode.includesSun {
+					solarRows
 				}
 
-				if solarDateIsInToday && (solar.safeSunrise ... solar.safeSunset).contains(solar.date) {
-					Label {
-						AdaptiveStack {
-							if let pinned = ScreenshotLaunch.displayDate {
-								// Text(timerInterval:) counts down against the real system clock,
-								// which a pinned capture must not leak; show the same remaining
-								// duration measured from the pinned instant instead.
-								Text(Duration.seconds(max(0, solar.safeSunset.timeIntervalSince(pinned)))
-									.formatted(.time(pattern: .hourMinuteSecond)))
-									.monospacedDigit()
-							} else {
-								Text(timerInterval: solar.safeSunrise ... solar.safeSunset)
-									.monospacedDigit()
-							}
-						} label: {
-							Text("Remaining daylight")
-						}
-					} icon: {
-						Image(systemName: "timer")
-					}
-				}
-
-				Label {
-					AdaptiveStack {
-						if let sunrise = solar.sunrise {
-							Text(sunrise, style: .time)
-						} else {
-							Text("—")
-						}
-					} label: {
-						Text("Sunrise")
-					}
-				} icon: {
-					Image(systemName: "sunrise")
-				}
-
-				Label {
-					AdaptiveStack {
-						if let solarNoon = solar.solarNoon {
-							Text(solarNoon, style: .time)
-						} else {
-							Text("—")
-						}
-					} label: {
-						Text("Solar noon")
-					}
-				} icon: {
-					Image(systemName: "sun.max")
-				}
-
-				Label {
-					AdaptiveStack {
-						if let sunset = solar.sunset {
-							Text(sunset, style: .time)
-						} else {
-							Text("—")
-						}
-					} label: {
-						Text("Sunset")
-					}
-				} icon: {
-					Image(systemName: "sunset")
+				if bodyMode.includesMoon, let moon {
+					lunarRows(for: moon)
 				}
 			}
 			.environment(\.timeZone, location.timeZone)
@@ -198,6 +138,130 @@ struct DailyOverview<Location: AnyLocation>: View {
 			}
 		}
 	}
+
+	@ViewBuilder
+	private var solarRows: some View {
+		Label {
+			AdaptiveStack {
+				Text(Duration.seconds(solar.daylightDuration).formatted(.units(maximumUnitCount: 2)))
+			} label: {
+				Text("Total daylight")
+			}
+		} icon: {
+			Image(systemName: "hourglass")
+		}
+
+		if solarDateIsInToday && (solar.safeSunrise ... solar.safeSunset).contains(solar.date) {
+			Label {
+				AdaptiveStack {
+					if let pinned = ScreenshotLaunch.displayDate {
+						// Text(timerInterval:) counts down against the real system clock,
+						// which a pinned capture must not leak; show the same remaining
+						// duration measured from the pinned instant instead.
+						Text(Duration.seconds(max(0, solar.safeSunset.timeIntervalSince(pinned)))
+							.formatted(.time(pattern: .hourMinuteSecond)))
+							.monospacedDigit()
+					} else {
+						Text(timerInterval: solar.safeSunrise ... solar.safeSunset)
+							.monospacedDigit()
+					}
+				} label: {
+					Text("Remaining daylight")
+				}
+			} icon: {
+				Image(systemName: "timer")
+			}
+		}
+
+		Label {
+			AdaptiveStack {
+				if let sunrise = solar.sunrise {
+					Text(sunrise, style: .time)
+				} else {
+					Text("—")
+				}
+			} label: {
+				Text("Sunrise")
+			}
+		} icon: {
+			Image(systemName: "sunrise")
+		}
+
+		Label {
+			AdaptiveStack {
+				if let solarNoon = solar.solarNoon {
+					Text(solarNoon, style: .time)
+				} else {
+					Text("—")
+				}
+			} label: {
+				Text("Solar noon")
+			}
+		} icon: {
+			Image(systemName: "sun.max")
+		}
+
+		Label {
+			AdaptiveStack {
+				if let sunset = solar.sunset {
+					Text(sunset, style: .time)
+				} else {
+					Text("—")
+				}
+			} label: {
+				Text("Sunset")
+			}
+		} icon: {
+			Image(systemName: "sunset")
+		}
+	}
+
+	/// The lunar counterpart of the solar rows. Moonrise and moonset are optional in a way
+	/// sunrise and sunset are not: the moon rises roughly 50 minutes later each day, so
+	/// about once a lunation a calendar day simply has no moonrise, or no moonset. That is
+	/// ordinary everywhere, not a polar edge case, and it renders as an em dash.
+	@ViewBuilder
+	private func lunarRows(for moon: LunarCalculator.Moon) -> some View {
+		Label {
+			AdaptiveStack {
+				Text(moon.formattedIllumination)
+			} label: {
+				Text(moon.phase.localizedName)
+			}
+		} icon: {
+			Image(systemName: moon.phase.symbolName(latitude: location.latitude))
+				.contentTransition(.symbolEffect)
+		}
+
+		Label {
+			AdaptiveStack {
+				if let moonrise = moon.moonrise {
+					Text(moonrise, style: .time)
+				} else {
+					Text("—")
+				}
+			} label: {
+				Text("Moonrise")
+			}
+		} icon: {
+			Image(systemName: "moonrise")
+		}
+
+		Label {
+			AdaptiveStack {
+				if let moonset = moon.moonset {
+					Text(moonset, style: .time)
+				} else {
+					Text("—")
+				}
+			} label: {
+				Text("Moonset")
+			}
+		} icon: {
+			Image(systemName: "moonset")
+		}
+	}
+
 }
 
 extension DailyOverview {

--- a/Solstice/Detail View/DetailView.swift
+++ b/Solstice/Detail View/DetailView.swift
@@ -170,9 +170,10 @@ struct DetailView<Location: ObservableLocation>: View {
 			)
 		}.value
 
-		withAnimation {
-			moon = result
-		}
+		// Assigned without animation on purpose. This task is keyed on the day, so during
+		// time travel it fires on every day change — animating here meant animating the
+		// whole form each time, which is what made scrubbing feel slow on device.
+		moon = result
 	}
 
 	private func findEclipse() async {

--- a/Solstice/Detail View/DetailView.swift
+++ b/Solstice/Detail View/DetailView.swift
@@ -28,6 +28,9 @@ struct DetailView<Location: ObservableLocation>: View {
 	@State private var showRemainingDaylight = false
 	@State private var showShareSheet = false
 	@State private var eclipse: EclipseCalculator.LocalCircumstances?
+	@State private var moon: LunarCalculator.Moon?
+
+	@AppStorage(Preferences.bodyMode) private var bodyMode
 
 	@AppStorage(Preferences.detailViewChartAppearance) private var chartAppearance
 	@SceneStorage("selectedLocation") private var selectedLocation: String?
@@ -55,7 +58,7 @@ struct DetailView<Location: ObservableLocation>: View {
 		ScrollViewReader { proxy in
 			Form {
 				if let solar {
-					DailyOverview(solar: solar, location: location)
+					DailyOverview(solar: solar, location: location, moon: moon)
 				}
 
 				if let eclipse {
@@ -68,6 +71,9 @@ struct DetailView<Location: ObservableLocation>: View {
 			.formStyle(.grouped)
 			.task(id: eclipseSearchKey) {
 				await findEclipse()
+			}
+			.task(id: moonSearchKey) {
+				await findMoon()
 			}
 			#if os(macOS)
 				// The macOS toolbar has no Share button to carry the detail-screen identifier
@@ -140,6 +146,35 @@ struct DetailView<Location: ObservableLocation>: View {
 		"\(location.latitude),\(location.longitude),\(timeMachine.date.startOfDay.timeIntervalSince1970)"
 	}
 
+	/// Keyed the same way the eclipse search is, and for the same reason: working out
+	/// moonrise samples the moon's position well over a hundred times, which has no place
+	/// in a computed property that re-evaluates on every body pass.
+	private var moonSearchKey: String {
+		"\(location.latitude),\(location.longitude),\(timeMachine.date.startOfDay.timeIntervalSince1970)"
+	}
+
+	/// Computed regardless of the current mode, deliberately. It costs a few hundred
+	/// microseconds off the main thread once per day and place, and doing it eagerly means
+	/// switching to the moon shows data immediately rather than after a round trip.
+	private func findMoon() async {
+		let latitude = location.latitude
+		let longitude = location.longitude
+		let date = timeMachine.date
+		let timeZone = location.timeZone
+
+		let result = await Task.detached(priority: .utility) {
+			LunarCalculator.moon(
+				for: date,
+				coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
+				timeZone: timeZone
+			)
+		}.value
+
+		withAnimation {
+			moon = result
+		}
+	}
+
 	private func findEclipse() async {
 		let latitude = location.latitude
 		let longitude = location.longitude
@@ -173,6 +208,35 @@ struct DetailView<Location: ObservableLocation>: View {
 
 	@ToolbarContentBuilder
 	var toolbarItems: some ToolbarContent {
+		ToolbarItem(placement: toolbarItemPlacement) {
+			#if os(watchOS)
+				// A menu is clumsy on the watch, so cycle instead. The label carries the
+				// current state, which is what makes cycling legible here.
+				Button {
+					withAnimation {
+						bodyMode = bodyMode.next
+					}
+				} label: {
+					Label(bodyMode.title, systemImage: bodyMode.icon)
+				}
+			#else
+				Menu {
+					Picker(selection: $bodyMode.animation()) {
+						ForEach(CelestialBodyMode.allCases) { mode in
+							Label(mode.title, systemImage: mode.icon)
+								.tag(mode)
+						}
+					} label: {
+						Text("Show")
+					}
+					.pickerStyle(.inline)
+				} label: {
+					Label(bodyMode.title, systemImage: bodyMode.icon)
+						.contentTransition(.symbolEffect)
+				}
+			#endif
+		}
+
 		#if !os(macOS)
 			ToolbarItem(placement: .topBarTrailing) {
 				Button("Share...", systemImage: "square.and.arrow.up") {

--- a/Solstice/Extensions/AppStorage++.swift
+++ b/Solstice/Extensions/AppStorage++.swift
@@ -71,6 +71,10 @@ enum Preferences {
 	/// The user preference for whether notifications include the time until the next solstice
 	static let notificationsIncludeSolsticeCountdown: Value = ("notifsIncludeSolsticeCountdown", false)
 
+	/// Which bodies the detail view's charts plot. Global rather than per-location, the
+	/// same way `chartType` is.
+	static let bodyMode: Value<CelestialBodyMode> = ("detailViewBodyMode", .solar)
+
 	/// The user preference for whether a major solar eclipse produces its own notifications.
 	///
 	/// Unlike the fragment toggles above this doesn't change the daily notification; it
@@ -192,6 +196,45 @@ enum ChartType: String, CaseIterable, RawRepresentable, Identifiable {
 		case .classic: return .solarchartLinear
 		case .circular: return .solarchartCircularFill
 		}
+	}
+
+	var id: Self {
+		self
+	}
+}
+
+/// Which bodies the detail view's charts plot.
+///
+/// The sky gradient stays solar whichever is chosen — it is driven by the sun's altitude,
+/// and keeping it as the backdrop is what makes the moon's path legible: you can see at a
+/// glance whether the moon is up in darkness or wasted in broad daylight.
+enum CelestialBodyMode: String, CaseIterable, RawRepresentable, Identifiable {
+	case solar, lunar, both
+
+	var title: LocalizedStringKey {
+		switch self {
+		case .solar: return "Sun"
+		case .lunar: return "Moon"
+		case .both: return "Sun and moon"
+		}
+	}
+
+	var icon: String {
+		switch self {
+		case .solar: return "sun.max"
+		case .lunar: return "moon"
+		case .both: return "moon.stars"
+		}
+	}
+
+	var includesSun: Bool { self != .lunar }
+	var includesMoon: Bool { self != .solar }
+
+	/// The next mode in the cycle, for the watchOS toolbar button where a menu is clumsy.
+	var next: CelestialBodyMode {
+		let all = Self.allCases
+		let index = all.firstIndex(of: self) ?? 0
+		return all[(index + 1) % all.count]
 	}
 
 	var id: Self {

--- a/Solstice/Extensions/LunarCalculator++.swift
+++ b/Solstice/Extensions/LunarCalculator++.swift
@@ -1,0 +1,56 @@
+//
+//  LunarCalculator++.swift
+//  Solstice
+//
+//  Created by Daniel Eden on 11/08/2026.
+//
+//  The app's presentation layer over `LunarCalculator`. Kept separate so the calculator
+//  itself imports nothing but Foundation and CoreLocation, and can be compiled into the
+//  widget targets without dragging SwiftUI along.
+//
+
+import SwiftUI
+
+extension LunarCalculator.Phase {
+	var localizedName: LocalizedStringKey {
+		switch self {
+		case .new: "New moon"
+		case .waxingCrescent: "Waxing crescent"
+		case .firstQuarter: "First quarter"
+		case .waxingGibbous: "Waxing gibbous"
+		case .full: "Full moon"
+		case .waningGibbous: "Waning gibbous"
+		case .lastQuarter: "Last quarter"
+		case .waningCrescent: "Waning crescent"
+		}
+	}
+
+	/// The SF Symbol for this phase, mirrored for southern-hemisphere observers.
+	///
+	/// The moon is lit from the same side for everyone, but observers south of the equator
+	/// see it the other way up, so the lit limb appears on the opposite side. SF Symbols
+	/// ships `.inverse` variants for exactly this. New and full moons are symmetrical and
+	/// need no variant.
+	func symbolName(latitude: Double) -> String {
+		let base: String
+		switch self {
+		case .new: return "moonphase.new.moon"
+		case .full: return "moonphase.full.moon"
+		case .waxingCrescent: base = "moonphase.waxing.crescent"
+		case .firstQuarter: base = "moonphase.first.quarter"
+		case .waxingGibbous: base = "moonphase.waxing.gibbous"
+		case .waningGibbous: base = "moonphase.waning.gibbous"
+		case .lastQuarter: base = "moonphase.last.quarter"
+		case .waningCrescent: base = "moonphase.waning.crescent"
+		}
+
+		return latitude < 0 ? "\(base).inverse" : base
+	}
+}
+
+extension LunarCalculator.Moon {
+	/// Illumination as a percentage string, e.g. "68%".
+	var formattedIllumination: String {
+		illuminatedFraction.formatted(.percent.precision(.fractionLength(0)))
+	}
+}

--- a/Solstice/Helpers/EclipseCalculator.swift
+++ b/Solstice/Helpers/EclipseCalculator.swift
@@ -6,17 +6,10 @@
 //
 //  Local circumstances for solar eclipses.
 //
-//  Source: Jean Meeus, *Astronomical Algorithms* (2nd edition, Willmann-Bell 1998) —
-//  chapter 22 (nutation and obliquity), chapter 25 (solar position), chapter 47 (lunar
-//  position, the truncated ELP-2000/82 series) and chapter 49 (phases of the moon).
-//  The ΔT model is the Espenak & Meeus polynomial set published with NASA's Five
-//  Millennium Canon of Solar Eclipses.
-//
-//  `NTSolar` deliberately isn't reused here. Its solar model is low order — it uses a
-//  linear obliquity and explicitly neglects aberration — which costs about an arcminute.
-//  Against the sun's ~16 arcminute semidiameter that is roughly 6% of eclipse magnitude,
-//  far too coarse to say "87% of the sun will be covered". Its internals are `private`
-//  to that file in any case, and it is vendored source that shouldn't be edited.
+//  Positions of the sun and moon come from `Ephemeris`, which holds the Meeus series and
+//  the coordinate machinery. What lives here is only the eclipse geometry: finding the
+//  lunations where a shadow reaches the Earth, and working out what an observer at one
+//  place sees of it.
 //
 //  Accuracy, checked against NASA's published circumstances:
 //
@@ -125,14 +118,14 @@ enum EclipseCalculator {
 	) -> [LocalCircumstances] {
 		guard endDate > startDate else { return [] }
 
-		let startJD = julianDay(from: startDate)
-		let endJD = julianDay(from: endDate)
+		let startJD = Ephemeris.julianDay(from: startDate)
+		let endJD = Ephemeris.julianDay(from: endDate)
 
 		// Solar eclipses only happen at new moon, so step lunation by lunation rather
 		// than scanning the whole window. `k` is Meeus's new moon index, zero at the new
 		// moon of 2000 January 6.
-		let firstK = Int(floor((decimalYear(julianDay: startJD) - 2000) * 12.3685)) - 1
-		let lastK = Int(ceil((decimalYear(julianDay: endJD) - 2000) * 12.3685)) + 1
+		let firstK = Int(floor(Ephemeris.lunationIndex(julianDay: startJD))) - 1
+		let lastK = Int(ceil(Ephemeris.lunationIndex(julianDay: endJD))) + 1
 
 		var results: [LocalCircumstances] = []
 
@@ -162,12 +155,12 @@ enum EclipseCalculator {
 	private static let horizonAltitude = -0.9
 
 	private static func eclipse(lunation k: Int, at coordinate: CLLocationCoordinate2D) -> LocalCircumstances? {
-		let meanNewMoonJDE = meanNewMoon(k: k)
-		let meanNewMoonJD = meanNewMoonJDE - deltaT(julianDay: meanNewMoonJDE) / 86400
+		let meanNewMoonJDE = Ephemeris.meanNewMoon(k: k)
+		let meanNewMoonJD = meanNewMoonJDE - Ephemeris.deltaT(julianDay: meanNewMoonJDE) / 86400
 
 		// Cheap rejection: if the moon passes far from the ecliptic at this new moon,
 		// its shadow misses the Earth entirely and there is nothing to compute.
-		let (_, moonLatitude, _) = lunarPosition(jde: meanNewMoonJDE)
+		let (_, moonLatitude, _) = Ephemeris.lunarPosition(jde: meanNewMoonJDE)
 		guard abs(moonLatitude) < latitudeScreen else { return nil }
 
 		// Coarse pass at 20 minute steps to find roughly when the eclipse peaks here.
@@ -350,43 +343,29 @@ enum EclipseCalculator {
 		}
 	}
 
-	/// Radius of the sun in kilometres. Chosen so the apparent semidiameter matches the
-	/// conventional 959.63 arcseconds at one astronomical unit.
-	private static let sunRadiusKm = 696_000.0
-
-	/// Radius of the moon in kilometres: the value `k = 0.272281` that NASA adopts for
-	/// umbral contacts, times the Earth's equatorial radius.
-	///
-	/// This is deliberately the umbral `k` rather than the slightly larger mean lunar
-	/// radius. The moon's limb is mountainous, and eclipse prediction has long adopted
-	/// the smaller figure so that computed durations of totality match what observers
-	/// actually time. Using it reproduces NASA's published eclipse magnitudes; the mean
-	/// radius overstates them by about 0.2%, which sounds negligible but lands squarely
-	/// on the difference of two nearly equal radii that sets how long totality lasts.
-	private static let moonRadiusKm = 1736.65
-
-	private static let earthRadiusKm = 6378.14
-	private static let astronomicalUnitKm = 149_597_870.7
-
 	private static func sample(at jd: Double, coordinate: CLLocationCoordinate2D) -> Sample {
-		let jde = jd + deltaT(julianDay: jd) / 86400
+		let jde = Ephemeris.julianEphemerisDay(fromJulianDay: jd)
 		let t = (jde - 2451545.0) / 36525.0
 
-		let (nutationLongitude, nutationObliquity) = nutation(t: t)
-		let obliquity = meanObliquity(t: t) + nutationObliquity
+		let (nutationLongitude, nutationObliquity) = Ephemeris.nutation(t: t)
+		let obliquity = Ephemeris.meanObliquity(t: t) + nutationObliquity
 
-		let (sunLongitude, sunDistanceAU) = solarPosition(jde: jde)
-		let apparentSunLongitude = sunLongitude + nutationLongitude - 20.4898 / 3600 / sunDistanceAU
+		let (sunLongitude, sunDistanceAU) = Ephemeris.solarPosition(jde: jde)
+		let apparentSunLongitude = Ephemeris.apparentSolarLongitude(
+			geometricLongitude: sunLongitude,
+			nutationLongitude: nutationLongitude,
+			distance: sunDistanceAU
+		)
 
-		let (moonLongitude, moonLatitude, moonDistanceKm) = lunarPosition(jde: jde)
+		let (moonLongitude, moonLatitude, moonDistanceKm) = Ephemeris.lunarPosition(jde: jde)
 		let apparentMoonLongitude = moonLongitude + nutationLongitude
 
-		let sun = equatorial(longitude: apparentSunLongitude, latitude: 0, obliquity: obliquity)
-		let moon = equatorial(longitude: apparentMoonLongitude, latitude: moonLatitude, obliquity: obliquity)
+		let sun = Ephemeris.equatorial(longitude: apparentSunLongitude, latitude: 0, obliquity: obliquity)
+		let moon = Ephemeris.equatorial(longitude: apparentMoonLongitude, latitude: moonLatitude, obliquity: obliquity)
 
 		// Apparent sidereal time is computed from UT, not TT — mixing the two here would
 		// put the observer in the wrong place by roughly a quarter of a degree.
-		let siderealTime = apparentSiderealTime(
+		let siderealTime = Ephemeris.apparentSiderealTime(
 			jd: jd,
 			nutationLongitude: nutationLongitude,
 			obliquity: obliquity
@@ -396,491 +375,52 @@ enum EclipseCalculator {
 		// The moon's horizontal parallax is nearly a degree — comparable to the whole
 		// geometry of an eclipse — so the observer's offset from the centre of the Earth
 		// is what makes an eclipse a local event at all.
-		let observer = observerVector(latitude: coordinate.latitude, localSiderealTime: localSiderealTime)
+		let observer = Ephemeris.observerVector(latitude: coordinate.latitude, localSiderealTime: localSiderealTime)
 
-		let sunTopocentric = topocentric(
+		let sunTopocentric = Ephemeris.topocentric(
 			rightAscension: sun.rightAscension,
 			declination: sun.declination,
-			distance: sunDistanceAU * astronomicalUnitKm,
+			distance: sunDistanceAU * Ephemeris.astronomicalUnitKm,
 			observer: observer
 		)
-		let moonTopocentric = topocentric(
+		let moonTopocentric = Ephemeris.topocentric(
 			rightAscension: moon.rightAscension,
 			declination: moon.declination,
 			distance: moonDistanceKm,
 			observer: observer
 		)
 
-		let separation = angularSeparation(
+		let separation = Ephemeris.angularSeparation(
 			rightAscension1: sunTopocentric.rightAscension,
 			declination1: sunTopocentric.declination,
 			rightAscension2: moonTopocentric.rightAscension,
 			declination2: moonTopocentric.declination
 		)
 
-		let hourAngle = localSiderealTime - sunTopocentric.rightAscension
-		let sunAltitude = degrees(asin(clamped(
-			sin(radians(coordinate.latitude)) * sin(radians(sunTopocentric.declination))
-				+ cos(radians(coordinate.latitude)) * cos(radians(sunTopocentric.declination))
-				* cos(radians(hourAngle))
-		)))
+		let sunAltitude = Ephemeris.altitude(
+			declination: sunTopocentric.declination,
+			hourAngle: localSiderealTime - sunTopocentric.rightAscension,
+			latitude: coordinate.latitude
+		)
 
+		// Note `umbralMoonRadiusKm`, not the mean radius: totality's duration falls out of
+		// the difference between two nearly equal radii, and this is the value that makes
+		// it agree with NASA's published figures.
 		return Sample(
 			separation: separation,
-			sunRadius: degrees(asin(clamped(sunRadiusKm / sunTopocentric.distance))),
-			moonRadius: degrees(asin(clamped(moonRadiusKm / moonTopocentric.distance))),
+			sunRadius: degrees(asin(clamped(Ephemeris.sunRadiusKm / sunTopocentric.distance))),
+			moonRadius: degrees(asin(clamped(Ephemeris.umbralMoonRadiusKm / moonTopocentric.distance))),
 			sunAltitude: sunAltitude
 		)
 	}
 
-	// MARK: - Coordinate machinery
+	// MARK: - Shared ephemeris
 
-	private struct EquatorialPosition {
-		let rightAscension: Double
-		let declination: Double
-		let distance: Double
-	}
+	// The general-purpose astronomy lives in `Ephemeris` so the moon can be used for
+	// things other than eclipses. These forward the few pure-maths helpers the eclipse
+	// geometry above reads most clearly without a namespace in front of them.
 
-	private static func equatorial(
-		longitude: Double,
-		latitude: Double,
-		obliquity: Double
-	) -> (rightAscension: Double, declination: Double) {
-		let l = radians(longitude)
-		let b = radians(latitude)
-		let e = radians(obliquity)
-
-		let rightAscension = atan2(sin(l) * cos(e) - tan(b) * sin(e), cos(l))
-		let declination = asin(clamped(sin(b) * cos(e) + cos(b) * sin(e) * sin(l)))
-
-		return (normalise(degrees(rightAscension)), degrees(declination))
-	}
-
-	/// The observer's position relative to the centre of the Earth, in kilometres, in the
-	/// same equatorial frame the bodies are expressed in.
-	private static func observerVector(latitude: Double, localSiderealTime: Double) -> (x: Double, y: Double, z: Double) {
-		// The Earth is flattened, so geodetic latitude has to be converted before it can
-		// be used as a direction from the centre.
-		let clampedLatitude = min(max(latitude, -89.9999), 89.9999)
-		let phi = radians(clampedLatitude)
-		let u = atan(0.99664719 * tan(phi))
-		let rhoSinPhi = 0.99664719 * sin(u)
-		let rhoCosPhi = cos(u)
-		let theta = radians(localSiderealTime)
-
-		return (
-			x: earthRadiusKm * rhoCosPhi * cos(theta),
-			y: earthRadiusKm * rhoCosPhi * sin(theta),
-			z: earthRadiusKm * rhoSinPhi
-		)
-	}
-
-	private static func topocentric(
-		rightAscension: Double,
-		declination: Double,
-		distance: Double,
-		observer: (x: Double, y: Double, z: Double)
-	) -> EquatorialPosition {
-		let ra = radians(rightAscension)
-		let dec = radians(declination)
-
-		let x = distance * cos(dec) * cos(ra) - observer.x
-		let y = distance * cos(dec) * sin(ra) - observer.y
-		let z = distance * sin(dec) - observer.z
-
-		let range = sqrt(x * x + y * y + z * z)
-
-		return EquatorialPosition(
-			rightAscension: normalise(degrees(atan2(y, x))),
-			declination: degrees(asin(clamped(z / range))),
-			distance: range
-		)
-	}
-
-	/// Great-circle distance in degrees, using the form that stays accurate for the very
-	/// small separations an eclipse involves.
-	private static func angularSeparation(
-		rightAscension1: Double,
-		declination1: Double,
-		rightAscension2: Double,
-		declination2: Double
-	) -> Double {
-		let d1 = radians(declination1)
-		let d2 = radians(declination2)
-		let deltaRA = radians(rightAscension2 - rightAscension1)
-
-		let numerator = sqrt(
-			pow(cos(d2) * sin(deltaRA), 2)
-				+ pow(cos(d1) * sin(d2) - sin(d1) * cos(d2) * cos(deltaRA), 2)
-		)
-		let denominator = sin(d1) * sin(d2) + cos(d1) * cos(d2) * cos(deltaRA)
-
-		return degrees(atan2(numerator, denominator))
-	}
-
-	private static func apparentSiderealTime(
-		jd: Double,
-		nutationLongitude: Double,
-		obliquity: Double
-	) -> Double {
-		let t = (jd - 2451545.0) / 36525.0
-		let mean = 280.46061837
-			+ 360.98564736629 * (jd - 2451545.0)
-			+ 0.000387933 * t * t
-			- t * t * t / 38_710_000.0
-
-		return normalise(mean + nutationLongitude * cos(radians(obliquity)))
-	}
-
-	// MARK: - Solar position (Meeus chapter 25)
-
-	/// Geometric longitude in degrees and radius vector in astronomical units.
-	private static func solarPosition(jde: Double) -> (longitude: Double, distance: Double) {
-		let t = (jde - 2451545.0) / 36525.0
-
-		let meanLongitude = 280.46646 + 36000.76983 * t + 0.0003032 * t * t
-		let meanAnomaly = 357.52911 + 35999.05029 * t - 0.0001537 * t * t
-		let eccentricity = 0.016708634 - 0.000042037 * t - 0.0000001267 * t * t
-
-		let m = radians(meanAnomaly)
-		let centre = (1.914602 - 0.004817 * t - 0.000014 * t * t) * sin(m)
-			+ (0.019993 - 0.000101 * t) * sin(2 * m)
-			+ 0.000289 * sin(3 * m)
-
-		let trueLongitude = meanLongitude + centre
-		let trueAnomaly = radians(meanAnomaly + centre)
-		let distance = 1.000001018 * (1 - eccentricity * eccentricity) / (1 + eccentricity * cos(trueAnomaly))
-
-		return (normalise(trueLongitude), distance)
-	}
-
-	// MARK: - Lunar position (Meeus chapter 47)
-
-	/// Apparent geocentric ecliptic longitude and latitude in degrees, and distance in
-	/// kilometres. Accurate to roughly 10 arcseconds in longitude and 4 in latitude,
-	/// which is a small fraction of a percent of eclipse obscuration.
-	private static func lunarPosition(jde: Double) -> (longitude: Double, latitude: Double, distance: Double) {
-		let t = (jde - 2451545.0) / 36525.0
-		let t2 = t * t
-		let t3 = t2 * t
-		let t4 = t3 * t
-
-		let meanLongitude = 218.3164477 + 481_267.88123421 * t - 0.0015786 * t2 + t3 / 538_841 - t4 / 65_194_000
-		let elongation = 297.8501921 + 445_267.1114034 * t - 0.0018819 * t2 + t3 / 545_868 - t4 / 113_065_000
-		let solarAnomaly = 357.5291092 + 35999.0502909 * t - 0.0001536 * t2 + t3 / 24_490_000
-		let lunarAnomaly = 134.9633964 + 477_198.8675055 * t + 0.0087414 * t2 + t3 / 69699 - t4 / 14_712_000
-		let argumentOfLatitude = 93.2720950 + 483_202.0175233 * t - 0.0036539 * t2 - t3 / 3_526_000 + t4 / 863_310_000
-
-		let a1 = 119.75 + 131.849 * t
-		let a2 = 53.09 + 479_264.290 * t
-		let a3 = 313.45 + 481_266.484 * t
-
-		// The sun's varying eccentricity damps terms involving its anomaly.
-		let e = 1 - 0.002516 * t - 0.0000074 * t2
-
-		var sumLongitude = 0.0
-		var sumDistance = 0.0
-
-		for term in lunarTermsA {
-			let argument = radians(
-				term[0] * elongation + term[1] * solarAnomaly
-					+ term[2] * lunarAnomaly + term[3] * argumentOfLatitude
-			)
-			let damping = pow(e, abs(term[1]))
-			sumLongitude += term[4] * damping * sin(argument)
-			sumDistance += term[5] * damping * cos(argument)
-		}
-
-		var sumLatitude = 0.0
-
-		for term in lunarTermsB {
-			let argument = radians(
-				term[0] * elongation + term[1] * solarAnomaly
-					+ term[2] * lunarAnomaly + term[3] * argumentOfLatitude
-			)
-			sumLatitude += term[4] * pow(e, abs(term[1])) * sin(argument)
-		}
-
-		// Additive terms for Venus, Jupiter and the flattening of the Earth.
-		sumLongitude += 3958 * sin(radians(a1))
-			+ 1962 * sin(radians(meanLongitude - argumentOfLatitude))
-			+ 318 * sin(radians(a2))
-
-		sumLatitude += -2235 * sin(radians(meanLongitude))
-			+ 382 * sin(radians(a3))
-			+ 175 * sin(radians(a1 - argumentOfLatitude))
-			+ 175 * sin(radians(a1 + argumentOfLatitude))
-			+ 127 * sin(radians(meanLongitude - lunarAnomaly))
-			- 115 * sin(radians(meanLongitude + lunarAnomaly))
-
-		return (
-			longitude: normalise(meanLongitude + sumLongitude / 1_000_000),
-			latitude: sumLatitude / 1_000_000,
-			distance: 385_000.56 + sumDistance / 1000
-		)
-	}
-
-	// MARK: - Nutation and obliquity (Meeus chapter 22)
-
-	private static func nutation(t: Double) -> (longitude: Double, obliquity: Double) {
-		let omega = radians(125.04452 - 1934.136261 * t)
-		let solarLongitude = radians(280.4665 + 36000.7698 * t)
-		let lunarLongitude = radians(218.3165 + 481_267.8813 * t)
-
-		let longitude = (-17.20 * sin(omega)
-			- 1.32 * sin(2 * solarLongitude)
-			- 0.23 * sin(2 * lunarLongitude)
-			+ 0.21 * sin(2 * omega)) / 3600
-
-		let obliquity = (9.20 * cos(omega)
-			+ 0.57 * cos(2 * solarLongitude)
-			+ 0.10 * cos(2 * lunarLongitude)
-			- 0.09 * cos(2 * omega)) / 3600
-
-		return (longitude, obliquity)
-	}
-
-	private static func meanObliquity(t: Double) -> Double {
-		23.0 + 26.0 / 60.0 + 21.448 / 3600.0
-			- (46.8150 * t + 0.00059 * t * t - 0.001813 * t * t * t) / 3600.0
-	}
-
-	// MARK: - New moon (Meeus chapter 49)
-
-	/// Mean new moon for lunation `k`, as a Julian Ephemeris Day. Only used as a starting
-	/// point — the true new moon can be over half a day either side, which the search
-	/// window around it absorbs.
-	private static func meanNewMoon(k: Int) -> Double {
-		let k = Double(k)
-		let t = k / 1236.85
-
-		return 2_451_550.09766
-			+ 29.530588861 * k
-			+ 0.00015437 * t * t
-			- 0.000000150 * t * t * t
-			+ 0.00000000073 * t * t * t * t
-	}
-
-	// MARK: - ΔT
-
-	/// The difference between Terrestrial Time and Universal Time in seconds.
-	///
-	/// Positions are computed in TT while the observer's rotation is tracked in UT;
-	/// getting this wrong simply shifts every predicted contact time by the same amount.
-	/// Polynomials from Espenak & Meeus.
-	private static func deltaT(julianDay: Double) -> Double {
-		let year = decimalYear(julianDay: julianDay)
-
-		switch year {
-		case ..<1920:
-			let t = year - 1900
-			return -2.79 + 1.494119 * t - 0.0598939 * t * t + 0.0061966 * t * t * t - 0.000197 * pow(t, 4)
-		case ..<1941:
-			let t = year - 1920
-			return 21.20 + 0.84493 * t - 0.076100 * t * t + 0.0020936 * t * t * t
-		case ..<1961:
-			let t = year - 1950
-			return 29.07 + 0.407 * t - t * t / 233 + t * t * t / 2547
-		case ..<1986:
-			let t = year - 1975
-			return 45.45 + 1.067 * t - t * t / 260 - t * t * t / 718
-		case ..<2005:
-			let t = year - 2000
-			return 63.86 + 0.3345 * t - 0.060374 * t * t + 0.0017275 * t * t * t
-				+ 0.000651814 * pow(t, 4) + 0.00002373599 * pow(t, 5)
-		case ..<2050:
-			let t = year - 2000
-			return 62.92 + 0.32217 * t + 0.005589 * t * t
-		case ..<2150:
-			return -20 + 32 * pow((year - 1820) / 100, 2) - 0.5628 * (2150 - year)
-		default:
-			let u = (year - 1820) / 100
-			return -20 + 32 * u * u
-		}
-	}
-
-	// MARK: - Julian day helpers
-
-	private static let julianDayAtUnixEpoch = 2_440_587.5
-
-	private static func julianDay(from date: Date) -> Double {
-		date.timeIntervalSince1970 / 86400 + julianDayAtUnixEpoch
-	}
-
-	private static func date(fromJulianDay julianDay: Double) -> Date {
-		Date(timeIntervalSince1970: (julianDay - julianDayAtUnixEpoch) * 86400)
-	}
-
-	/// Year with a fractional part, derived arithmetically rather than through `Calendar`.
-	///
-	/// The ΔT polynomials are defined over proleptic Gregorian years, and reading a year
-	/// back through the user's calendar would give the wrong answer in a non-Gregorian
-	/// region — the same hazard `SolsticeCalculator` documents.
-	private static func decimalYear(julianDay: Double) -> Double {
-		let z = (julianDay + 0.5).rounded(.down)
-
-		var a = z
-		if z >= 2_299_161 {
-			let alpha = ((z - 1_867_216.25) / 36524.25).rounded(.down)
-			a = z + 1 + alpha - (alpha / 4).rounded(.down)
-		}
-
-		let b = a + 1524
-		let c = ((b - 122.1) / 365.25).rounded(.down)
-		let d = (365.25 * c).rounded(.down)
-		let e = ((b - d) / 30.6001).rounded(.down)
-
-		let month = e < 14 ? e - 1 : e - 13
-		let year = month > 2 ? c - 4716 : c - 4715
-
-		return year + (month - 0.5) / 12
-	}
-
-	// MARK: - Small helpers
-
-	private static func radians(_ degrees: Double) -> Double { degrees * .pi / 180 }
-	private static func degrees(_ radians: Double) -> Double { radians * 180 / .pi }
-
-	private static func normalise(_ degrees: Double) -> Double {
-		let wrapped = degrees.truncatingRemainder(dividingBy: 360)
-		return wrapped < 0 ? wrapped + 360 : wrapped
-	}
-
-	/// Guards the inverse trigonometric functions against arguments that drift a hair
-	/// outside their domain through rounding.
-	private static func clamped(_ value: Double) -> Double {
-		min(max(value, -1), 1)
-	}
-
-	// MARK: - Periodic terms
-
-	/// Meeus table 47.A — columns are the multiples of D, M, M′ and F, then the
-	/// coefficients for longitude (units of 1e-6 degrees) and distance (units of metres).
-	private static let lunarTermsA: [[Double]] = [
-		[0, 0, 1, 0, 6_288_774, -20_905_355],
-		[2, 0, -1, 0, 1_274_027, -3_699_111],
-		[2, 0, 0, 0, 658_314, -2_955_968],
-		[0, 0, 2, 0, 213_618, -569_925],
-		[0, 1, 0, 0, -185_116, 48888],
-		[0, 0, 0, 2, -114_332, -3149],
-		[2, 0, -2, 0, 58793, 246_158],
-		[2, -1, -1, 0, 57066, -152_138],
-		[2, 0, 1, 0, 53322, -170_733],
-		[2, -1, 0, 0, 45758, -204_586],
-		[0, 1, -1, 0, -40923, -129_620],
-		[1, 0, 0, 0, -34720, 108_743],
-		[0, 1, 1, 0, -30383, 104_755],
-		[2, 0, 0, -2, 15327, 10321],
-		[0, 0, 1, 2, -12528, 0],
-		[0, 0, 1, -2, 10980, 79661],
-		[4, 0, -1, 0, 10675, -34782],
-		[0, 0, 3, 0, 10034, -23210],
-		[4, 0, -2, 0, 8548, -21636],
-		[2, 1, -1, 0, -7888, 24208],
-		[2, 1, 0, 0, -6766, 30824],
-		[1, 0, -1, 0, -5163, -8379],
-		[1, 1, 0, 0, 4987, -16675],
-		[2, -1, 1, 0, 4036, -12831],
-		[2, 0, 2, 0, 3994, -10445],
-		[4, 0, 0, 0, 3861, -11650],
-		[2, 0, -3, 0, 3665, 14403],
-		[0, 1, -2, 0, -2689, -7003],
-		[2, 0, -1, 2, -2602, 0],
-		[2, -1, -2, 0, 2390, 10056],
-		[1, 0, 1, 0, -2348, 6322],
-		[2, -2, 0, 0, 2236, -9884],
-		[0, 1, 2, 0, -2120, 5751],
-		[0, 2, 0, 0, -2069, 0],
-		[2, -2, -1, 0, 2048, -4950],
-		[2, 0, 1, -2, -1773, 4130],
-		[2, 0, 0, 2, -1595, 0],
-		[4, -1, -1, 0, 1215, -3958],
-		[0, 0, 2, 2, -1110, 0],
-		[3, 0, -1, 0, -892, 3258],
-		[2, 1, 1, 0, -810, 2616],
-		[4, -1, -2, 0, 759, -1897],
-		[0, 2, -1, 0, -713, -2117],
-		[2, 2, -1, 0, -700, 2354],
-		[2, 1, -2, 0, 691, 0],
-		[2, -1, 0, -2, 596, 0],
-		[4, 0, 1, 0, 549, -1423],
-		[0, 0, 4, 0, 537, -1117],
-		[4, -1, 0, 0, 520, -1571],
-		[1, 0, -2, 0, -487, -1739],
-		[2, 1, 0, -2, -399, 0],
-		[0, 0, 2, -2, -381, -4421],
-		[1, 1, 1, 0, 351, 0],
-		[3, 0, -2, 0, -340, 0],
-		[4, 0, -3, 0, 330, 0],
-		[2, -1, 2, 0, 327, 0],
-		[0, 2, 1, 0, -323, 1165],
-		[1, 1, -1, 0, 299, 0],
-		[2, 0, 3, 0, 294, 0],
-		[2, 0, -1, -2, 0, 8752],
-	]
-
-	/// Meeus table 47.B — columns are the multiples of D, M, M′ and F, then the
-	/// coefficient for latitude (units of 1e-6 degrees).
-	private static let lunarTermsB: [[Double]] = [
-		[0, 0, 0, 1, 5_128_122],
-		[0, 0, 1, 1, 280_602],
-		[0, 0, 1, -1, 277_693],
-		[2, 0, 0, -1, 173_237],
-		[2, 0, -1, 1, 55413],
-		[2, 0, -1, -1, 46271],
-		[2, 0, 0, 1, 32573],
-		[0, 0, 2, 1, 17198],
-		[2, 0, 1, -1, 9266],
-		[0, 0, 2, -1, 8822],
-		[2, -1, 0, -1, 8216],
-		[2, 0, -2, -1, 4324],
-		[2, 0, 1, 1, 4200],
-		[2, 1, 0, -1, -3359],
-		[2, -1, -1, 1, 2463],
-		[2, -1, 0, 1, 2211],
-		[2, -1, -1, -1, 2065],
-		[0, 1, -1, -1, -1870],
-		[4, 0, -1, -1, 1828],
-		[0, 1, 0, 1, -1794],
-		[0, 0, 0, 3, -1749],
-		[0, 1, -1, 1, -1565],
-		[1, 0, 0, 1, -1491],
-		[0, 1, 1, 1, -1475],
-		[0, 1, 1, -1, -1410],
-		[0, 1, 0, -1, -1344],
-		[1, 0, 0, -1, -1335],
-		[0, 0, 3, 1, 1107],
-		[4, 0, 0, -1, 1021],
-		[4, 0, -1, 1, 833],
-		[0, 0, 1, -3, 777],
-		[4, 0, -2, 1, 671],
-		[2, 0, 0, -3, 607],
-		[2, 0, 2, -1, 596],
-		[2, -1, 1, -1, 491],
-		[2, 0, -2, 1, -451],
-		[0, 0, 3, -1, 439],
-		[2, 0, 2, 1, 422],
-		[2, 0, -3, -1, 421],
-		[2, 1, -1, 1, -366],
-		[2, 1, 0, 1, -351],
-		[4, 0, 0, 1, 331],
-		[2, -1, 1, 1, 315],
-		[2, -2, 0, -1, 302],
-		[0, 0, 1, 3, -283],
-		[2, 1, 1, -1, -229],
-		[1, 1, 0, -1, 223],
-		[1, 1, 0, 1, 223],
-		[0, 1, -2, -1, -220],
-		[2, 1, -1, -1, -220],
-		[1, 0, 1, 1, -185],
-		[2, -1, -2, -1, 181],
-		[0, 1, 2, 1, -177],
-		[4, 0, -2, -1, 176],
-		[4, -1, -1, -1, 166],
-		[1, 0, 1, -1, -164],
-		[4, 0, 1, -1, 132],
-		[1, 0, -1, -1, -119],
-		[4, -1, 0, -1, 115],
-		[2, -2, 0, 1, 107],
-	]
+	private static func radians(_ degrees: Double) -> Double { Ephemeris.radians(degrees) }
+	private static func degrees(_ radians: Double) -> Double { Ephemeris.degrees(radians) }
+	private static func clamped(_ value: Double) -> Double { Ephemeris.clamped(value) }
 }

--- a/Solstice/Helpers/EclipseCalculator.swift
+++ b/Solstice/Helpers/EclipseCalculator.swift
@@ -207,9 +207,9 @@ enum EclipseCalculator {
 			kind: kind,
 			obscuration: peak.obscuration,
 			magnitude: peak.magnitude,
-			firstContact: date(fromJulianDay: firstContact),
-			maximum: date(fromJulianDay: best.jd),
-			lastContact: date(fromJulianDay: lastContact),
+			firstContact: Ephemeris.date(fromJulianDay: firstContact),
+			maximum: Ephemeris.date(fromJulianDay: best.jd),
+			lastContact: Ephemeris.date(fromJulianDay: lastContact),
 			centralDuration: centralDuration,
 			sunAltitudeAtMaximum: peak.sunAltitude
 		)

--- a/Solstice/Helpers/Ephemeris.swift
+++ b/Solstice/Helpers/Ephemeris.swift
@@ -1,0 +1,549 @@
+//
+//  Ephemeris.swift
+//  Solstice
+//
+//  Created by Daniel Eden on 11/08/2026.
+//
+//  Positions of the sun and moon, and the coordinate machinery for converting them into
+//  what an observer at a particular place would actually see.
+//
+//  Source: Jean Meeus, *Astronomical Algorithms* (2nd edition, Willmann-Bell 1998) —
+//  chapter 12 (sidereal time), chapter 13 (coordinate transformation), chapter 22
+//  (nutation and obliquity), chapter 25 (solar position), chapter 40 (parallax),
+//  chapter 47 (lunar position, the truncated ELP-2000/82 series) and chapter 49 (phases
+//  of the moon). The ΔT model is the Espenak & Meeus polynomial set published with
+//  NASA's Five Millennium Canon of Solar Eclipses.
+//
+//  This started life inside `EclipseCalculator` and was lifted out unchanged so the moon
+//  could be used for something other than eclipses. Accuracy is Meeus's: roughly 10
+//  arcseconds in lunar longitude and 4 in latitude, which is a fraction of a percent of
+//  the apparent size of either body.
+//
+//  `NTSolar` is not used for any of this. Its solar model is low order — linear obliquity,
+//  aberration explicitly neglected — which costs about an arcminute, and its internals are
+//  private to that file in any case.
+//
+
+import Foundation
+
+enum Ephemeris {
+	// MARK: - Constants
+
+	/// Radius of the sun in kilometres. Chosen so the apparent semidiameter matches the
+	/// conventional 959.63 arcseconds at one astronomical unit.
+	static let sunRadiusKm = 696_000.0
+
+	/// Radius of the moon in kilometres, from the IAU `k = 0.2725076` times the Earth's
+	/// equatorial radius. The right figure for how large the moon *looks*.
+	static let moonRadiusKm = 1738.09
+
+	/// Radius of the moon in kilometres from the smaller `k = 0.272281` that NASA adopts
+	/// for umbral contacts.
+	///
+	/// Only eclipse totality should use this. The moon's limb is mountainous, and eclipse
+	/// prediction has long adopted the smaller figure so computed durations of totality
+	/// match what observers actually time — it reproduces NASA's published eclipse
+	/// magnitudes, where `moonRadiusKm` overstates them by about 0.2%. That sounds
+	/// negligible until it lands on the difference between two nearly equal radii, which
+	/// is exactly what sets how long totality lasts. For anything else — the moon's
+	/// apparent size, moonrise, illumination — it is simply the wrong number.
+	static let umbralMoonRadiusKm = 1736.65
+
+	static let earthRadiusKm = 6378.14
+	static let astronomicalUnitKm = 149_597_870.7
+
+	// MARK: - Julian day
+
+	private static let julianDayAtUnixEpoch = 2_440_587.5
+
+	static func julianDay(from date: Date) -> Double {
+		date.timeIntervalSince1970 / 86400 + julianDayAtUnixEpoch
+	}
+
+	static func date(fromJulianDay julianDay: Double) -> Date {
+		Date(timeIntervalSince1970: (julianDay - julianDayAtUnixEpoch) * 86400)
+	}
+
+	/// Year with a fractional part, derived arithmetically rather than through `Calendar`.
+	///
+	/// The ΔT polynomials are defined over proleptic Gregorian years, and reading a year
+	/// back through the user's calendar would give the wrong answer in a non-Gregorian
+	/// region — the same hazard `SolsticeCalculator` documents.
+	static func decimalYear(julianDay: Double) -> Double {
+		let z = (julianDay + 0.5).rounded(.down)
+
+		var a = z
+		if z >= 2_299_161 {
+			let alpha = ((z - 1_867_216.25) / 36524.25).rounded(.down)
+			a = z + 1 + alpha - (alpha / 4).rounded(.down)
+		}
+
+		let b = a + 1524
+		let c = ((b - 122.1) / 365.25).rounded(.down)
+		let d = (365.25 * c).rounded(.down)
+		let e = ((b - d) / 30.6001).rounded(.down)
+
+		let month = e < 14 ? e - 1 : e - 13
+		let year = month > 2 ? c - 4716 : c - 4715
+
+		return year + (month - 0.5) / 12
+	}
+
+	// MARK: - ΔT
+
+	/// The difference between Terrestrial Time and Universal Time in seconds.
+	///
+	/// Positions are computed in TT while the observer's rotation is tracked in UT;
+	/// getting this wrong simply shifts every predicted time by the same amount.
+	/// Polynomials from Espenak & Meeus.
+	static func deltaT(julianDay: Double) -> Double {
+		let year = decimalYear(julianDay: julianDay)
+
+		switch year {
+		case ..<1920:
+			let t = year - 1900
+			return -2.79 + 1.494119 * t - 0.0598939 * t * t + 0.0061966 * t * t * t - 0.000197 * pow(t, 4)
+		case ..<1941:
+			let t = year - 1920
+			return 21.20 + 0.84493 * t - 0.076100 * t * t + 0.0020936 * t * t * t
+		case ..<1961:
+			let t = year - 1950
+			return 29.07 + 0.407 * t - t * t / 233 + t * t * t / 2547
+		case ..<1986:
+			let t = year - 1975
+			return 45.45 + 1.067 * t - t * t / 260 - t * t * t / 718
+		case ..<2005:
+			let t = year - 2000
+			return 63.86 + 0.3345 * t - 0.060374 * t * t + 0.0017275 * t * t * t
+				+ 0.000651814 * pow(t, 4) + 0.00002373599 * pow(t, 5)
+		case ..<2050:
+			let t = year - 2000
+			return 62.92 + 0.32217 * t + 0.005589 * t * t
+		case ..<2150:
+			return -20 + 32 * pow((year - 1820) / 100, 2) - 0.5628 * (2150 - year)
+		default:
+			let u = (year - 1820) / 100
+			return -20 + 32 * u * u
+		}
+	}
+
+	/// Julian Ephemeris Day (Terrestrial Time) for a Julian Day in Universal Time.
+	static func julianEphemerisDay(fromJulianDay jd: Double) -> Double {
+		jd + deltaT(julianDay: jd) / 86400
+	}
+
+	// MARK: - Nutation and obliquity (Meeus chapter 22)
+
+	static func nutation(t: Double) -> (longitude: Double, obliquity: Double) {
+		let omega = radians(125.04452 - 1934.136261 * t)
+		let solarLongitude = radians(280.4665 + 36000.7698 * t)
+		let lunarLongitude = radians(218.3165 + 481_267.8813 * t)
+
+		let longitude = (-17.20 * sin(omega)
+			- 1.32 * sin(2 * solarLongitude)
+			- 0.23 * sin(2 * lunarLongitude)
+			+ 0.21 * sin(2 * omega)) / 3600
+
+		let obliquity = (9.20 * cos(omega)
+			+ 0.57 * cos(2 * solarLongitude)
+			+ 0.10 * cos(2 * lunarLongitude)
+			- 0.09 * cos(2 * omega)) / 3600
+
+		return (longitude, obliquity)
+	}
+
+	static func meanObliquity(t: Double) -> Double {
+		23.0 + 26.0 / 60.0 + 21.448 / 3600.0
+			- (46.8150 * t + 0.00059 * t * t - 0.001813 * t * t * t) / 3600.0
+	}
+
+	// MARK: - Solar position (Meeus chapter 25)
+
+	/// Geometric longitude in degrees and radius vector in astronomical units.
+	static func solarPosition(jde: Double) -> (longitude: Double, distance: Double) {
+		let t = (jde - 2451545.0) / 36525.0
+
+		let meanLongitude = 280.46646 + 36000.76983 * t + 0.0003032 * t * t
+		let meanAnomaly = 357.52911 + 35999.05029 * t - 0.0001537 * t * t
+		let eccentricity = 0.016708634 - 0.000042037 * t - 0.0000001267 * t * t
+
+		let m = radians(meanAnomaly)
+		let centre = (1.914602 - 0.004817 * t - 0.000014 * t * t) * sin(m)
+			+ (0.019993 - 0.000101 * t) * sin(2 * m)
+			+ 0.000289 * sin(3 * m)
+
+		let trueLongitude = meanLongitude + centre
+		let trueAnomaly = radians(meanAnomaly + centre)
+		let distance = 1.000001018 * (1 - eccentricity * eccentricity) / (1 + eccentricity * cos(trueAnomaly))
+
+		return (normalise(trueLongitude), distance)
+	}
+
+	/// Apparent solar longitude in degrees — geometric longitude with nutation and the
+	/// aberration of light applied.
+	///
+	/// Takes the already-computed geometric position rather than recomputing it, since
+	/// callers invoke this inside tight sampling loops.
+	static func apparentSolarLongitude(
+		geometricLongitude: Double,
+		nutationLongitude: Double,
+		distance: Double
+	) -> Double {
+		geometricLongitude + nutationLongitude - 20.4898 / 3600 / distance
+	}
+
+	// MARK: - Lunar position (Meeus chapter 47)
+
+	/// Apparent geocentric ecliptic longitude and latitude in degrees, and distance in
+	/// kilometres. Accurate to roughly 10 arcseconds in longitude and 4 in latitude.
+	static func lunarPosition(jde: Double) -> (longitude: Double, latitude: Double, distance: Double) {
+		let t = (jde - 2451545.0) / 36525.0
+		let t2 = t * t
+		let t3 = t2 * t
+		let t4 = t3 * t
+
+		let meanLongitude = 218.3164477 + 481_267.88123421 * t - 0.0015786 * t2 + t3 / 538_841 - t4 / 65_194_000
+		let elongation = 297.8501921 + 445_267.1114034 * t - 0.0018819 * t2 + t3 / 545_868 - t4 / 113_065_000
+		let solarAnomaly = 357.5291092 + 35999.0502909 * t - 0.0001536 * t2 + t3 / 24_490_000
+		let lunarAnomaly = 134.9633964 + 477_198.8675055 * t + 0.0087414 * t2 + t3 / 69699 - t4 / 14_712_000
+		let argumentOfLatitude = 93.2720950 + 483_202.0175233 * t - 0.0036539 * t2 - t3 / 3_526_000 + t4 / 863_310_000
+
+		let a1 = 119.75 + 131.849 * t
+		let a2 = 53.09 + 479_264.290 * t
+		let a3 = 313.45 + 481_266.484 * t
+
+		// The sun's varying eccentricity damps terms involving its anomaly.
+		let e = 1 - 0.002516 * t - 0.0000074 * t2
+
+		var sumLongitude = 0.0
+		var sumDistance = 0.0
+
+		for term in lunarTermsA {
+			let argument = radians(
+				term[0] * elongation + term[1] * solarAnomaly
+					+ term[2] * lunarAnomaly + term[3] * argumentOfLatitude
+			)
+			let damping = pow(e, abs(term[1]))
+			sumLongitude += term[4] * damping * sin(argument)
+			sumDistance += term[5] * damping * cos(argument)
+		}
+
+		var sumLatitude = 0.0
+
+		for term in lunarTermsB {
+			let argument = radians(
+				term[0] * elongation + term[1] * solarAnomaly
+					+ term[2] * lunarAnomaly + term[3] * argumentOfLatitude
+			)
+			sumLatitude += term[4] * pow(e, abs(term[1])) * sin(argument)
+		}
+
+		// Additive terms for Venus, Jupiter and the flattening of the Earth.
+		sumLongitude += 3958 * sin(radians(a1))
+			+ 1962 * sin(radians(meanLongitude - argumentOfLatitude))
+			+ 318 * sin(radians(a2))
+
+		sumLatitude += -2235 * sin(radians(meanLongitude))
+			+ 382 * sin(radians(a3))
+			+ 175 * sin(radians(a1 - argumentOfLatitude))
+			+ 175 * sin(radians(a1 + argumentOfLatitude))
+			+ 127 * sin(radians(meanLongitude - lunarAnomaly))
+			- 115 * sin(radians(meanLongitude + lunarAnomaly))
+
+		return (
+			longitude: normalise(meanLongitude + sumLongitude / 1_000_000),
+			latitude: sumLatitude / 1_000_000,
+			distance: 385_000.56 + sumDistance / 1000
+		)
+	}
+
+	/// The moon's equatorial horizontal parallax in degrees — how far its apparent
+	/// position shifts between the centre of the Earth and a point on its surface. Nearly
+	/// a degree, which is why anything lunar has to be computed topocentrically.
+	static func lunarHorizontalParallax(distance: Double) -> Double {
+		degrees(asin(clamped(earthRadiusKm / distance)))
+	}
+
+	// MARK: - Phases of the moon (Meeus chapter 49)
+
+	/// Mean new moon for lunation `k`, as a Julian Ephemeris Day. A starting point only —
+	/// the true new moon can be over half a day either side.
+	static func meanNewMoon(k: Int) -> Double {
+		let k = Double(k)
+		let t = k / 1236.85
+
+		return 2_451_550.09766
+			+ 29.530588861 * k
+			+ 0.00015437 * t * t
+			- 0.000000150 * t * t * t
+			+ 0.00000000073 * t * t * t * t
+	}
+
+	/// Meeus's lunation index for a moment, zero at the new moon of 2000 January 6.
+	static func lunationIndex(julianDay: Double) -> Double {
+		(decimalYear(julianDay: julianDay) - 2000) * 12.3685
+	}
+
+	/// The mean length of a lunation in days.
+	static let synodicMonth = 29.530588861
+
+	// MARK: - Coordinate machinery
+
+	struct EquatorialPosition {
+		let rightAscension: Double
+		let declination: Double
+		let distance: Double
+	}
+
+	static func equatorial(
+		longitude: Double,
+		latitude: Double,
+		obliquity: Double
+	) -> (rightAscension: Double, declination: Double) {
+		let l = radians(longitude)
+		let b = radians(latitude)
+		let e = radians(obliquity)
+
+		let rightAscension = atan2(sin(l) * cos(e) - tan(b) * sin(e), cos(l))
+		let declination = asin(clamped(sin(b) * cos(e) + cos(b) * sin(e) * sin(l)))
+
+		return (normalise(degrees(rightAscension)), degrees(declination))
+	}
+
+	/// The observer's position relative to the centre of the Earth, in kilometres, in the
+	/// same equatorial frame the bodies are expressed in.
+	static func observerVector(latitude: Double, localSiderealTime: Double) -> (x: Double, y: Double, z: Double) {
+		// The Earth is flattened, so geodetic latitude has to be converted before it can
+		// be used as a direction from the centre.
+		let clampedLatitude = min(max(latitude, -89.9999), 89.9999)
+		let phi = radians(clampedLatitude)
+		let u = atan(0.99664719 * tan(phi))
+		let rhoSinPhi = 0.99664719 * sin(u)
+		let rhoCosPhi = cos(u)
+		let theta = radians(localSiderealTime)
+
+		return (
+			x: earthRadiusKm * rhoCosPhi * cos(theta),
+			y: earthRadiusKm * rhoCosPhi * sin(theta),
+			z: earthRadiusKm * rhoSinPhi
+		)
+	}
+
+	static func topocentric(
+		rightAscension: Double,
+		declination: Double,
+		distance: Double,
+		observer: (x: Double, y: Double, z: Double)
+	) -> EquatorialPosition {
+		let ra = radians(rightAscension)
+		let dec = radians(declination)
+
+		let x = distance * cos(dec) * cos(ra) - observer.x
+		let y = distance * cos(dec) * sin(ra) - observer.y
+		let z = distance * sin(dec) - observer.z
+
+		let range = sqrt(x * x + y * y + z * z)
+
+		return EquatorialPosition(
+			rightAscension: normalise(degrees(atan2(y, x))),
+			declination: degrees(asin(clamped(z / range))),
+			distance: range
+		)
+	}
+
+	/// Great-circle distance in degrees, using the form that stays accurate for very
+	/// small separations.
+	static func angularSeparation(
+		rightAscension1: Double,
+		declination1: Double,
+		rightAscension2: Double,
+		declination2: Double
+	) -> Double {
+		let d1 = radians(declination1)
+		let d2 = radians(declination2)
+		let deltaRA = radians(rightAscension2 - rightAscension1)
+
+		let numerator = sqrt(
+			pow(cos(d2) * sin(deltaRA), 2)
+				+ pow(cos(d1) * sin(d2) - sin(d1) * cos(d2) * cos(deltaRA), 2)
+		)
+		let denominator = sin(d1) * sin(d2) + cos(d1) * cos(d2) * cos(deltaRA)
+
+		return degrees(atan2(numerator, denominator))
+	}
+
+	static func apparentSiderealTime(
+		jd: Double,
+		nutationLongitude: Double,
+		obliquity: Double
+	) -> Double {
+		let t = (jd - 2451545.0) / 36525.0
+		let mean = 280.46061837
+			+ 360.98564736629 * (jd - 2451545.0)
+			+ 0.000387933 * t * t
+			- t * t * t / 38_710_000.0
+
+		return normalise(mean + nutationLongitude * cos(radians(obliquity)))
+	}
+
+	/// Altitude above the horizon in degrees for a body already in topocentric
+	/// coordinates.
+	static func altitude(
+		declination: Double,
+		hourAngle: Double,
+		latitude: Double
+	) -> Double {
+		degrees(asin(clamped(
+			sin(radians(latitude)) * sin(radians(declination))
+				+ cos(radians(latitude)) * cos(radians(declination)) * cos(radians(hourAngle))
+		)))
+	}
+
+	// MARK: - Small helpers
+
+	static func radians(_ degrees: Double) -> Double { degrees * .pi / 180 }
+	static func degrees(_ radians: Double) -> Double { radians * 180 / .pi }
+
+	static func normalise(_ degrees: Double) -> Double {
+		let wrapped = degrees.truncatingRemainder(dividingBy: 360)
+		return wrapped < 0 ? wrapped + 360 : wrapped
+	}
+
+	/// Guards the inverse trigonometric functions against arguments that drift a hair
+	/// outside their domain through rounding.
+	static func clamped(_ value: Double) -> Double {
+		min(max(value, -1), 1)
+	}
+
+	// MARK: - Periodic terms
+
+	/// Meeus table 47.A — columns are the multiples of D, M, M′ and F, then the
+	/// coefficients for longitude (units of 1e-6 degrees) and distance (units of metres).
+	private static let lunarTermsA: [[Double]] = [
+		[0, 0, 1, 0, 6_288_774, -20_905_355],
+		[2, 0, -1, 0, 1_274_027, -3_699_111],
+		[2, 0, 0, 0, 658_314, -2_955_968],
+		[0, 0, 2, 0, 213_618, -569_925],
+		[0, 1, 0, 0, -185_116, 48888],
+		[0, 0, 0, 2, -114_332, -3149],
+		[2, 0, -2, 0, 58793, 246_158],
+		[2, -1, -1, 0, 57066, -152_138],
+		[2, 0, 1, 0, 53322, -170_733],
+		[2, -1, 0, 0, 45758, -204_586],
+		[0, 1, -1, 0, -40923, -129_620],
+		[1, 0, 0, 0, -34720, 108_743],
+		[0, 1, 1, 0, -30383, 104_755],
+		[2, 0, 0, -2, 15327, 10321],
+		[0, 0, 1, 2, -12528, 0],
+		[0, 0, 1, -2, 10980, 79661],
+		[4, 0, -1, 0, 10675, -34782],
+		[0, 0, 3, 0, 10034, -23210],
+		[4, 0, -2, 0, 8548, -21636],
+		[2, 1, -1, 0, -7888, 24208],
+		[2, 1, 0, 0, -6766, 30824],
+		[1, 0, -1, 0, -5163, -8379],
+		[1, 1, 0, 0, 4987, -16675],
+		[2, -1, 1, 0, 4036, -12831],
+		[2, 0, 2, 0, 3994, -10445],
+		[4, 0, 0, 0, 3861, -11650],
+		[2, 0, -3, 0, 3665, 14403],
+		[0, 1, -2, 0, -2689, -7003],
+		[2, 0, -1, 2, -2602, 0],
+		[2, -1, -2, 0, 2390, 10056],
+		[1, 0, 1, 0, -2348, 6322],
+		[2, -2, 0, 0, 2236, -9884],
+		[0, 1, 2, 0, -2120, 5751],
+		[0, 2, 0, 0, -2069, 0],
+		[2, -2, -1, 0, 2048, -4950],
+		[2, 0, 1, -2, -1773, 4130],
+		[2, 0, 0, 2, -1595, 0],
+		[4, -1, -1, 0, 1215, -3958],
+		[0, 0, 2, 2, -1110, 0],
+		[3, 0, -1, 0, -892, 3258],
+		[2, 1, 1, 0, -810, 2616],
+		[4, -1, -2, 0, 759, -1897],
+		[0, 2, -1, 0, -713, -2117],
+		[2, 2, -1, 0, -700, 2354],
+		[2, 1, -2, 0, 691, 0],
+		[2, -1, 0, -2, 596, 0],
+		[4, 0, 1, 0, 549, -1423],
+		[0, 0, 4, 0, 537, -1117],
+		[4, -1, 0, 0, 520, -1571],
+		[1, 0, -2, 0, -487, -1739],
+		[2, 1, 0, -2, -399, 0],
+		[0, 0, 2, -2, -381, -4421],
+		[1, 1, 1, 0, 351, 0],
+		[3, 0, -2, 0, -340, 0],
+		[4, 0, -3, 0, 330, 0],
+		[2, -1, 2, 0, 327, 0],
+		[0, 2, 1, 0, -323, 1165],
+		[1, 1, -1, 0, 299, 0],
+		[2, 0, 3, 0, 294, 0],
+		[2, 0, -1, -2, 0, 8752],
+	]
+
+	/// Meeus table 47.B — columns are the multiples of D, M, M′ and F, then the
+	/// coefficient for latitude (units of 1e-6 degrees).
+	private static let lunarTermsB: [[Double]] = [
+		[0, 0, 0, 1, 5_128_122],
+		[0, 0, 1, 1, 280_602],
+		[0, 0, 1, -1, 277_693],
+		[2, 0, 0, -1, 173_237],
+		[2, 0, -1, 1, 55413],
+		[2, 0, -1, -1, 46271],
+		[2, 0, 0, 1, 32573],
+		[0, 0, 2, 1, 17198],
+		[2, 0, 1, -1, 9266],
+		[0, 0, 2, -1, 8822],
+		[2, -1, 0, -1, 8216],
+		[2, 0, -2, -1, 4324],
+		[2, 0, 1, 1, 4200],
+		[2, 1, 0, -1, -3359],
+		[2, -1, -1, 1, 2463],
+		[2, -1, 0, 1, 2211],
+		[2, -1, -1, -1, 2065],
+		[0, 1, -1, -1, -1870],
+		[4, 0, -1, -1, 1828],
+		[0, 1, 0, 1, -1794],
+		[0, 0, 0, 3, -1749],
+		[0, 1, -1, 1, -1565],
+		[1, 0, 0, 1, -1491],
+		[0, 1, 1, 1, -1475],
+		[0, 1, 1, -1, -1410],
+		[0, 1, 0, -1, -1344],
+		[1, 0, 0, -1, -1335],
+		[0, 0, 3, 1, 1107],
+		[4, 0, 0, -1, 1021],
+		[4, 0, -1, 1, 833],
+		[0, 0, 1, -3, 777],
+		[4, 0, -2, 1, 671],
+		[2, 0, 0, -3, 607],
+		[2, 0, 2, -1, 596],
+		[2, -1, 1, -1, 491],
+		[2, 0, -2, 1, -451],
+		[0, 0, 3, -1, 439],
+		[2, 0, 2, 1, 422],
+		[2, 0, -3, -1, 421],
+		[2, 1, -1, 1, -366],
+		[2, 1, 0, 1, -351],
+		[4, 0, 0, 1, 331],
+		[2, -1, 1, 1, 315],
+		[2, -2, 0, -1, 302],
+		[0, 0, 1, 3, -283],
+		[2, 1, 1, -1, -229],
+		[1, 1, 0, -1, 223],
+		[1, 1, 0, 1, 223],
+		[0, 1, -2, -1, -220],
+		[2, 1, -1, -1, -220],
+		[1, 0, 1, 1, -185],
+		[2, -1, -2, -1, 181],
+		[0, 1, 2, 1, -177],
+		[4, 0, -2, -1, 176],
+		[4, -1, -1, -1, 166],
+		[1, 0, 1, -1, -164],
+		[4, 0, 1, -1, 132],
+		[1, 0, -1, -1, -119],
+		[4, -1, 0, -1, 115],
+		[2, -2, 0, 1, 107],
+	]
+}

--- a/Solstice/Helpers/LunarCalculator.swift
+++ b/Solstice/Helpers/LunarCalculator.swift
@@ -1,0 +1,361 @@
+//
+//  LunarCalculator.swift
+//  Solstice
+//
+//  Created by Daniel Eden on 11/08/2026.
+//
+//  What the moon is doing at a place on a day: when it rises and sets, how much of it is
+//  lit, and where it is in the sky.
+//
+//  Positions come from `Ephemeris`. Illumination follows Meeus chapter 48; rising and
+//  setting are solved directly rather than by Meeus's chapter 15 interpolation, because
+//  the ephemeris already gives topocentric positions and sampling them is both simpler
+//  and more robust near the awkward cases.
+//
+
+import CoreLocation
+import Foundation
+
+enum LunarCalculator {
+	// MARK: - Public types
+
+	/// The eight conventional phases, each a 45° slice of the lunation centred on the
+	/// principal phase it is named for.
+	enum Phase: String, CaseIterable, Hashable, Sendable {
+		case new, waxingCrescent, firstQuarter, waxingGibbous
+		case full, waningGibbous, lastQuarter, waningCrescent
+
+		/// Whether the lit fraction is growing.
+		var isWaxing: Bool {
+			switch self {
+			case .new, .waxingCrescent, .firstQuarter, .waxingGibbous: true
+			case .full, .waningGibbous, .lastQuarter, .waningCrescent: false
+			}
+		}
+	}
+
+	/// The four phases that are instants rather than ranges, and so can be searched for.
+	enum PrincipalPhase: Hashable, Sendable {
+		case new, firstQuarter, full, lastQuarter
+
+		/// Elongation from the sun, in degrees, that defines this phase.
+		var elongation: Double {
+			switch self {
+			case .new: 0
+			case .firstQuarter: 90
+			case .full: 180
+			case .lastQuarter: 270
+			}
+		}
+	}
+
+	struct Moon: Hashable, Sendable {
+		let date: Date
+
+		/// When the moon's upper limb clears the horizon, or `nil` on a day it does not
+		/// rise at all.
+		///
+		/// A missing value here is ordinary, not an error. The moon rises roughly 50
+		/// minutes later each day, so about once a lunation a calendar day contains no
+		/// moonrise — or no moonset. Unlike the polar cases `NTSolar` handles, this
+		/// happens at every latitude, every month.
+		let moonrise: Date?
+		let moonset: Date?
+
+		/// Fraction of the moon's disc that is lit, 0...1.
+		let illuminatedFraction: Double
+
+		let phase: Phase
+
+		/// Elongation from the sun in degrees, 0 at new moon and 180 at full. Drives the
+		/// phase glyph, which needs the continuous value rather than the bucketed one.
+		let elongation: Double
+
+		/// Distance to the moon in kilometres.
+		let distance: Double
+
+		/// Whether the moon is above the horizon at `date`.
+		let isUp: Bool
+	}
+
+	// MARK: - Public API
+
+	static func moon(
+		for date: Date,
+		coordinate: CLLocationCoordinate2D,
+		timeZone: TimeZone = .autoupdatingCurrent
+	) -> Moon {
+		var calendar = Calendar(identifier: .gregorian)
+		calendar.timeZone = timeZone
+		let dayStart = calendar.startOfDay(for: date)
+
+		let (moonrise, moonset) = riseAndSet(onDayStarting: dayStart, coordinate: coordinate)
+
+		let jd = Ephemeris.julianDay(from: date)
+		let jde = Ephemeris.julianEphemerisDay(fromJulianDay: jd)
+		let illumination = illumination(jde: jde)
+		let (_, _, distance) = Ephemeris.lunarPosition(jde: jde)
+
+		return Moon(
+			date: date,
+			moonrise: moonrise,
+			moonset: moonset,
+			illuminatedFraction: illumination.fraction,
+			phase: phase(forElongation: illumination.elongation),
+			elongation: illumination.elongation,
+			distance: distance,
+			isUp: altitude(at: date, coordinate: coordinate) > 0
+		)
+	}
+
+	/// The moon's altitude above the horizon in degrees, topocentric.
+	static func altitude(at date: Date, coordinate: CLLocationCoordinate2D) -> Double {
+		position(at: Ephemeris.julianDay(from: date), coordinate: coordinate).altitude
+	}
+
+	/// The next time the moon reaches a principal phase after `date`.
+	static func nextPhaseEvent(_ phase: PrincipalPhase, after date: Date) -> Date? {
+		let start = Ephemeris.julianDay(from: date)
+		// Six-hour steps advance the elongation by about 3°, comfortably fine enough to
+		// bracket a crossing without mistaking it for the 360° wrap.
+		let step = 0.25
+		let limit = Ephemeris.synodicMonth + 2
+
+		var previous = start
+		var previousOffset = elongationOffset(at: start, target: phase.elongation)
+		var elapsed = step
+
+		while elapsed <= limit {
+			let jd = start + elapsed
+			let offset = elongationOffset(at: jd, target: phase.elongation)
+
+			// A genuine crossing steps a few degrees from negative to positive. The wrap
+			// from +180 to −180 halfway round the lunation jumps by hundreds, so the
+			// magnitude check keeps it from being mistaken for one.
+			if previousOffset < 0, offset >= 0, abs(offset - previousOffset) < 90 {
+				return Ephemeris.date(fromJulianDay: refineElongation(
+					from: previous, to: jd, target: phase.elongation
+				))
+			}
+
+			previous = jd
+			previousOffset = offset
+			elapsed += step
+		}
+
+		return nil
+	}
+
+	// MARK: - Illumination (Meeus chapter 48)
+
+	private static func illumination(jde: Double) -> (fraction: Double, elongation: Double) {
+		// Geometric longitudes are enough here: nutation shifts both bodies by the same
+		// amount and cancels in the elongation, and aberration is far below the precision
+		// an illuminated fraction is quoted to.
+		let (sunLongitude, sunDistanceAU) = Ephemeris.solarPosition(jde: jde)
+		let (moonLongitude, moonLatitude, moonDistance) = Ephemeris.lunarPosition(jde: jde)
+
+		let sunDistance = sunDistanceAU * Ephemeris.astronomicalUnitKm
+
+		// Geocentric elongation of the moon from the sun.
+		let cosPsi = Ephemeris.clamped(
+			cos(Ephemeris.radians(moonLatitude)) * cos(Ephemeris.radians(moonLongitude - sunLongitude))
+		)
+		let psi = acos(cosPsi)
+
+		// Phase angle: the sun–moon–Earth angle. Note the moon is much nearer than the
+		// sun, so this is nowhere near equal to 180° − elongation.
+		let phaseAngle = atan2(
+			sunDistance * sin(psi),
+			moonDistance - sunDistance * cos(psi)
+		)
+
+		return (
+			fraction: (1 + cos(phaseAngle)) / 2,
+			elongation: Ephemeris.normalise(moonLongitude - sunLongitude)
+		)
+	}
+
+	/// How far either side of an exact principal phase still counts as that phase — a
+	/// little over half a day.
+	private static let principalPhaseWindow = 7.5
+
+	private static func phase(forElongation elongation: Double) -> Phase {
+		// The four principal phases get a narrow window and the crescents and gibbous
+		// phases take everything between. Splitting the lunation into eight equal 45°
+		// slices instead would be simpler, but it would call a moon that is 68% lit
+		// "first quarter" — a first quarter moon is half lit, and anyone looking up would
+		// see the app was wrong.
+		func isNear(_ target: Double) -> Bool {
+			abs(Ephemeris.normalise(elongation - target + 180) - 180) <= principalPhaseWindow
+		}
+
+		if isNear(0) { return .new }
+		if isNear(90) { return .firstQuarter }
+		if isNear(180) { return .full }
+		if isNear(270) { return .lastQuarter }
+
+		switch elongation {
+		case ..<90: return .waxingCrescent
+		case ..<180: return .waxingGibbous
+		case ..<270: return .waningGibbous
+		default: return .waningCrescent
+		}
+	}
+
+	/// Signed difference between the elongation at `jd` and a target, wrapped to
+	/// −180...180 so it passes cleanly through zero at the crossing.
+	private static func elongationOffset(at jd: Double, target: Double) -> Double {
+		let jde = Ephemeris.julianEphemerisDay(fromJulianDay: jd)
+		let elongation = illumination(jde: jde).elongation
+		let difference = Ephemeris.normalise(elongation - target)
+		return difference > 180 ? difference - 360 : difference
+	}
+
+	private static func refineElongation(from low: Double, to high: Double, target: Double) -> Double {
+		var low = low
+		var high = high
+
+		for _ in 0 ..< 30 {
+			let middle = (low + high) / 2
+			if elongationOffset(at: middle, target: target) < 0 {
+				low = middle
+			} else {
+				high = middle
+			}
+		}
+
+		return (low + high) / 2
+	}
+
+	// MARK: - Rising and setting
+
+	/// Refraction at the horizon, in degrees.
+	private static let refraction = 34.0 / 60.0
+
+	/// Altitude of the moon's *centre* at the moment its upper limb touches the horizon.
+	///
+	/// Meeus quotes `h₀ = 0.7275·π − 34′` for this, but that figure is for use with
+	/// *geocentric* positions: the `0.7275·π` term exists to fold in parallax, which
+	/// lowers the moon by nearly a degree near the horizon, along with its semidiameter.
+	/// `Ephemeris` hands back topocentric positions, so parallax is already applied and
+	/// applying it again would put moonrise out by the better part of two hours. What is
+	/// left is refraction and the semidiameter, exactly as for the sun.
+	private static func standardAltitude(topocentricDistance: Double) -> Double {
+		let semidiameter = Ephemeris.degrees(
+			asin(Ephemeris.clamped(Ephemeris.moonRadiusKm / topocentricDistance))
+		)
+		return -refraction - semidiameter
+	}
+
+	private static func position(
+		at jd: Double,
+		coordinate: CLLocationCoordinate2D
+	) -> (altitude: Double, distance: Double) {
+		let jde = Ephemeris.julianEphemerisDay(fromJulianDay: jd)
+		let t = (jde - 2451545.0) / 36525.0
+
+		let (nutationLongitude, nutationObliquity) = Ephemeris.nutation(t: t)
+		let obliquity = Ephemeris.meanObliquity(t: t) + nutationObliquity
+
+		let (longitude, latitude, distance) = Ephemeris.lunarPosition(jde: jde)
+		let equatorial = Ephemeris.equatorial(
+			longitude: longitude + nutationLongitude,
+			latitude: latitude,
+			obliquity: obliquity
+		)
+
+		let siderealTime = Ephemeris.apparentSiderealTime(
+			jd: jd,
+			nutationLongitude: nutationLongitude,
+			obliquity: obliquity
+		)
+		let localSiderealTime = siderealTime + coordinate.longitude
+		let observer = Ephemeris.observerVector(
+			latitude: coordinate.latitude,
+			localSiderealTime: localSiderealTime
+		)
+
+		let topocentric = Ephemeris.topocentric(
+			rightAscension: equatorial.rightAscension,
+			declination: equatorial.declination,
+			distance: distance,
+			observer: observer
+		)
+
+		let altitude = Ephemeris.altitude(
+			declination: topocentric.declination,
+			hourAngle: localSiderealTime - topocentric.rightAscension,
+			latitude: coordinate.latitude
+		)
+
+		return (altitude, topocentric.distance)
+	}
+
+	/// How far the moon is above or below the altitude at which it rises. Positive means
+	/// visible.
+	private static func elevation(at jd: Double, coordinate: CLLocationCoordinate2D) -> Double {
+		let (altitude, distance) = position(at: jd, coordinate: coordinate)
+		return altitude - standardAltitude(topocentricDistance: distance)
+	}
+
+	/// Scans the 24 hours from `dayStart` for horizon crossings.
+	///
+	/// Ten-minute steps are comfortably finer than the moon's motion — it takes well over
+	/// half an hour to cross its own diameter — so no crossing can hide between samples.
+	private static func riseAndSet(
+		onDayStarting dayStart: Date,
+		coordinate: CLLocationCoordinate2D
+	) -> (moonrise: Date?, moonset: Date?) {
+		let start = Ephemeris.julianDay(from: dayStart)
+		let step = 10.0 / 1440.0
+		let steps = Int((1.0 / step).rounded())
+
+		var moonrise: Date?
+		var moonset: Date?
+
+		var previousJD = start
+		var previousElevation = elevation(at: start, coordinate: coordinate)
+
+		for index in 1 ... steps {
+			let jd = start + Double(index) * step
+			let currentElevation = elevation(at: jd, coordinate: coordinate)
+
+			if previousElevation < 0, currentElevation >= 0, moonrise == nil {
+				moonrise = Ephemeris.date(fromJulianDay: refineCrossing(
+					from: previousJD, to: jd, coordinate: coordinate
+				))
+			} else if previousElevation >= 0, currentElevation < 0, moonset == nil {
+				moonset = Ephemeris.date(fromJulianDay: refineCrossing(
+					from: previousJD, to: jd, coordinate: coordinate
+				))
+			}
+
+			previousJD = jd
+			previousElevation = currentElevation
+		}
+
+		return (moonrise, moonset)
+	}
+
+	private static func refineCrossing(
+		from low: Double,
+		to high: Double,
+		coordinate: CLLocationCoordinate2D
+	) -> Double {
+		var low = low
+		var high = high
+		let startsBelow = elevation(at: low, coordinate: coordinate) < 0
+
+		for _ in 0 ..< 25 {
+			let middle = (low + high) / 2
+			if (elevation(at: middle, coordinate: coordinate) < 0) == startsBelow {
+				low = middle
+			} else {
+				high = middle
+			}
+		}
+
+		return (low + high) / 2
+	}
+}

--- a/SolsticeTests/LunarCalculatorTests.swift
+++ b/SolsticeTests/LunarCalculatorTests.swift
@@ -1,0 +1,263 @@
+//
+//  LunarCalculatorTests.swift
+//  SolsticeTests
+//
+//  Reference values come from Meeus's own worked examples where they exist, and from
+//  physical relationships that hold regardless of implementation where they don't.
+//
+//  Lifting the ephemeris out of `EclipseCalculator` made the first kind possible: the
+//  lunar series can now be checked directly against the book rather than only indirectly,
+//  through whether an eclipse came out in the right place.
+//
+
+import CoreLocation
+import Foundation
+@testable import Solstice
+import Testing
+
+struct LunarCalculatorTests {
+	/// Reference times are quoted in UT and the search windows are built from calendar
+	/// components, so both have to be read in a calendar that agrees. Going through
+	/// `Calendar.current` would fail on a runner whose region defaults to a non-Gregorian
+	/// calendar even though the calculator is correct — the same guard
+	/// `SolsticeCalculatorTests` documents.
+	private static let utcGregorian: Calendar = {
+		var calendar = Calendar(identifier: .gregorian)
+		calendar.timeZone = TimeZone(identifier: "UTC") ?? .gmt
+		return calendar
+	}()
+
+	private static func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0, _ minute: Int = 0) -> Date {
+		var components = DateComponents()
+		components.year = year
+		components.month = month
+		components.day = day
+		components.hour = hour
+		components.minute = minute
+		return utcGregorian.date(from: components) ?? .distantPast
+	}
+
+	private static let london = CLLocationCoordinate2D(latitude: 51.5072, longitude: -0.1276)
+	private static let utc = TimeZone(identifier: "UTC") ?? .gmt
+
+	private func minutes(between first: Date, and second: Date) -> Double {
+		abs(first.timeIntervalSince(second)) / 60
+	}
+
+	// MARK: - The ephemeris, against the book
+
+	/// Meeus example 47.a. This is the whole lunar series pinned in one assertion — it was
+	/// only ever checked indirectly before the extraction.
+	@Test("Lunar position matches Meeus example 47.a")
+	func lunarPositionMatchesMeeus() {
+		let (longitude, latitude, distance) = Ephemeris.lunarPosition(jde: 2_448_724.5)
+
+		#expect(abs(longitude - 133.162655) < 0.000001)
+		#expect(abs(latitude - -3.229126) < 0.000001)
+		#expect(abs(distance - 368_409.7) < 0.1)
+	}
+
+	/// Meeus example 25.b. The radius vector uses the lower-precision method, so it is
+	/// held to a looser bound than the longitude.
+	@Test("Solar position matches Meeus example 25.b")
+	func solarPositionMatchesMeeus() {
+		let (longitude, distance) = Ephemeris.solarPosition(jde: 2_448_908.5)
+
+		#expect(abs(longitude - 199.90987) < 0.0001)
+		#expect(abs(distance - 0.99760775) < 0.0001)
+	}
+
+	/// Meeus example 48.a, for the same instant as 47.a. The example is quoted at 00:00
+	/// TD; a `Date` at 00:00 UT is about 59 seconds earlier in 1992, which moves the
+	/// fraction by under 0.0001.
+	@Test("Illuminated fraction matches Meeus example 48.a")
+	func illuminatedFractionMatchesMeeus() {
+		let moon = LunarCalculator.moon(
+			for: Self.date(1992, 4, 12),
+			coordinate: Self.london,
+			timeZone: Self.utc
+		)
+
+		#expect(abs(moon.illuminatedFraction - 0.6786) < 0.001)
+		#expect(moon.phase == .waxingGibbous)
+	}
+
+	// MARK: - Rising and setting
+
+	/// The check that catches the mistake this solver is most likely to make. Meeus's
+	/// `h₀ = 0.7275·π − 34′` is for geocentric positions; applying it to the topocentric
+	/// ones the ephemeris returns would double-count parallax and shift moonrise by well
+	/// over an hour. At full moon the moon rises as the sun sets, so an error of that size
+	/// is impossible to miss here.
+	@Test("The full moon rises as the sun sets")
+	func fullMoonRisesAtSunset() throws {
+		let fullMoon = try #require(
+			LunarCalculator.nextPhaseEvent(.full, after: Self.date(2026, 8, 1))
+		)
+
+		let moon = LunarCalculator.moon(for: fullMoon, coordinate: Self.london, timeZone: Self.utc)
+		let moonrise = try #require(moon.moonrise)
+
+		let solar = try #require(NTSolar(
+			for: moonrise,
+			coordinate: Self.london,
+			timeZone: Self.utc
+		))
+
+		// Within half an hour of sunset — the two are not exactly simultaneous, since the
+		// moon is a little off the ecliptic and refraction differs slightly.
+		#expect(minutes(between: moonrise, and: solar.safeSunset) < 30)
+	}
+
+	@Test("Moonrise and moonset bracket the moon being above the horizon")
+	func crossingsGoTheRightWay() throws {
+		let moon = LunarCalculator.moon(
+			for: Self.date(2026, 8, 14),
+			coordinate: Self.london,
+			timeZone: Self.utc
+		)
+
+		let moonrise = try #require(moon.moonrise)
+		let moonset = try #require(moon.moonset)
+
+		let beforeRise = LunarCalculator.altitude(at: moonrise.addingTimeInterval(-600), coordinate: Self.london)
+		let afterRise = LunarCalculator.altitude(at: moonrise.addingTimeInterval(600), coordinate: Self.london)
+		#expect(beforeRise < afterRise)
+
+		let beforeSet = LunarCalculator.altitude(at: moonset.addingTimeInterval(-600), coordinate: Self.london)
+		let afterSet = LunarCalculator.altitude(at: moonset.addingTimeInterval(600), coordinate: Self.london)
+		#expect(beforeSet > afterSet)
+	}
+
+	/// The moon rises about fifty minutes later each day, so roughly once a lunation a
+	/// calendar day has no moonrise — or no moonset. Ordinary, and the UI has to cope.
+	@Test("A day with no moonset still reports a moonrise")
+	func dayWithoutMoonset() {
+		let moon = LunarCalculator.moon(
+			for: Self.date(2026, 8, 23),
+			coordinate: Self.london,
+			timeZone: Self.utc
+		)
+
+		#expect(moon.moonrise != nil)
+		#expect(moon.moonset == nil)
+	}
+
+	@Test("A day with no moonrise still reports a moonset")
+	func dayWithoutMoonrise() {
+		let moon = LunarCalculator.moon(
+			for: Self.date(2026, 9, 6),
+			coordinate: Self.london,
+			timeZone: Self.utc
+		)
+
+		#expect(moon.moonrise == nil)
+		#expect(moon.moonset != nil)
+	}
+
+	// MARK: - Phases
+
+	/// Solar eclipses only happen at new moon, so the phase search and the eclipse search
+	/// — written independently of one another — have to agree about when this one is. They
+	/// are not measuring quite the same thing: conjunction in ecliptic longitude is not
+	/// the instant of greatest eclipse for a particular observer, which is why the bound
+	/// is half an hour rather than seconds.
+	@Test("The phase search agrees with the eclipse search about the 2026 new moon")
+	func newMoonAgreesWithEclipse() throws {
+		let newMoon = try #require(
+			LunarCalculator.nextPhaseEvent(.new, after: Self.date(2026, 8, 1))
+		)
+
+		let eclipse = try #require(EclipseCalculator.eclipses(
+			at: CLLocationCoordinate2D(latitude: 64.1466, longitude: -21.9426),
+			from: Self.date(2026, 8, 1),
+			through: Self.date(2026, 8, 31),
+			minimumObscuration: 0
+		).first)
+
+		#expect(minutes(between: newMoon, and: eclipse.maximum) < 30)
+	}
+
+	@Test("Successive full moons are a synodic month apart")
+	func fullMoonsAreALunationApart() throws {
+		var date = Self.date(2026, 8, 1)
+		var intervals: [Double] = []
+
+		for _ in 0 ..< 4 {
+			let full = try #require(LunarCalculator.nextPhaseEvent(.full, after: date))
+			if date != Self.date(2026, 8, 1) {
+				intervals.append(full.timeIntervalSince(date) / 86400)
+			}
+			date = full
+		}
+
+		// The synodic month is 29.53 days on average and varies by about half a day.
+		#expect(intervals.allSatisfy { $0 > 29.0 && $0 < 30.1 })
+	}
+
+	@Test("Illumination peaks at full moon and bottoms at new")
+	func illuminationTracksPhase() throws {
+		let full = try #require(LunarCalculator.nextPhaseEvent(.full, after: Self.date(2026, 8, 1)))
+		let new = try #require(LunarCalculator.nextPhaseEvent(.new, after: Self.date(2026, 8, 1)))
+
+		let atFull = LunarCalculator.moon(for: full, coordinate: Self.london, timeZone: Self.utc)
+		let atNew = LunarCalculator.moon(for: new, coordinate: Self.london, timeZone: Self.utc)
+
+		#expect(atFull.illuminatedFraction > 0.99)
+		#expect(atFull.phase == .full)
+		#expect(atNew.illuminatedFraction < 0.01)
+		#expect(atNew.phase == .new)
+	}
+
+	/// Walking a whole lunation should pass through all eight phases in order, and the
+	/// waxing half should come before the waning half.
+	@Test("A lunation passes through every phase in order")
+	func lunationCoversEveryPhase() throws {
+		let new = try #require(LunarCalculator.nextPhaseEvent(.new, after: Self.date(2026, 8, 1)))
+
+		var seen: [LunarCalculator.Phase] = []
+		for hour in stride(from: 0.0, to: 29.5 * 24, by: 6) {
+			let moon = LunarCalculator.moon(
+				for: new.addingTimeInterval(hour * 3600),
+				coordinate: Self.london,
+				timeZone: Self.utc
+			)
+			if seen.last != moon.phase {
+				seen.append(moon.phase)
+			}
+		}
+
+		let expected: [LunarCalculator.Phase] = [
+			.new, .waxingCrescent, .firstQuarter, .waxingGibbous,
+			.full, .waningGibbous, .lastQuarter, .waningCrescent,
+		]
+
+		#expect(seen.prefix(expected.count) == ArraySlice(expected))
+		#expect(expected.prefix(4).allSatisfy(\.isWaxing))
+		#expect(expected.suffix(4).allSatisfy { !$0.isWaxing })
+	}
+
+	// MARK: - Invariants
+
+	@Test("Distance stays within the moon's real range")
+	func distanceIsPlausible() {
+		for day in stride(from: 0, to: 60, by: 3) {
+			let moon = LunarCalculator.moon(
+				for: Self.date(2026, 8, 1).addingTimeInterval(Double(day) * 86400),
+				coordinate: Self.london,
+				timeZone: Self.utc
+			)
+
+			// Perigee and apogee bracket roughly 356,500 to 406,700 km.
+			#expect(moon.distance > 355_000 && moon.distance < 408_000)
+		}
+	}
+
+	@Test("Repeated queries agree")
+	func repeatedQueriesAgree() {
+		let first = LunarCalculator.moon(for: Self.date(2026, 8, 14), coordinate: Self.london, timeZone: Self.utc)
+		let second = LunarCalculator.moon(for: Self.date(2026, 8, 14), coordinate: Self.london, timeZone: Self.utc)
+
+		#expect(first == second)
+	}
+}


### PR DESCRIPTION
Stacked on #166 — based on `claude/solstice-solar-eclipse-n2k27c` so the diff shows only the lunar work. Retarget to `main` once #166 merges.

Adds a toolbar control that switches the detail view between the sun, the moon, and both.

## Why this was cheaper than it looks

`EclipseCalculator` already held a complete Meeus lunar theory — chapter 47's truncated ELP-2000/82 series, topocentric parallax, nutation, sidereal time and ΔT — and every bit of it was `private`. None of it is specific to eclipses. The first commit lifts it into `Ephemeris`; the second builds on it.

The extraction is numerically inert, and checkably so: counting every numeric literal across both files gives **937 before and 937 after**. The only differences are the lunation index going from spelled out twice to once, and two new constants. `EclipseCalculatorTests` is unchanged and is the real check.

One constant deliberately does not become the default. The moon radius in `EclipseCalculator` was the umbral `k = 0.272281`, chosen so totality durations match NASA's, and it is the wrong figure for how large the moon *looks*. `Ephemeris` exposes the mean radius as `moonRadiusKm` and keeps the eclipse value as `umbralMoonRadiusKm`.

## The one piece of genuinely new astronomy

Moonrise and moonset. The sun's fall out of a single daily position; the moon moves ~13°/day, so altitude is sampled across the local day and the crossings bisected.

**The trap worth knowing about:** Meeus gives `h₀ = 0.7275·π − 34′` for moonrise, but that is for *geocentric* positions — the `0.7275·π` term exists to fold in parallax. `Ephemeris` returns topocentric positions, where parallax is already applied, so using Meeus's figure would move moonrise by the better part of two hours. What remains is refraction and the semidiameter, as for the sun. The test that the full moon rises as the sun sets exists to catch exactly that.

Both times are optional, and a missing one is ordinary rather than an error: about once a lunation a calendar day has no moonrise, or no moonset, at every latitude.

## Phases

Eight equal 45° slices would label a moon that is 68% lit "first quarter" — a first quarter moon is half lit, and anyone who looked up would see the app was wrong. The four principal phases get a narrow window instead and the crescents and gibbous phases take everything between. Meeus's own worked example falls in that gap and now reads as waxing gibbous.

Glyphs are mirrored below the equator: the moon is lit from the same side for everyone, but southern observers see it the other way up.

## Verification

Asserted against the book, which the extraction made possible for the first time — these were previously only checked indirectly, through whether an eclipse landed in the right place:

| Reference | Result |
|---|---|
| Meeus 47.a (lunar position) | λ, β, Δ to six decimal places |
| Meeus 25.b (solar position) | matches |
| Meeus 48.a (illuminated fraction) | 0.6786 |

And against physics, where no published example exists:

- The full moon rises as the sun sets — sun altitude at moonrise came out at −0.94°.
- Daily retardation of moonrise is 11–23 min at London in late summer, not the "average" 50 — the shallow-ecliptic-angle effect behind the Harvest Moon.
- Successive full moons a synodic month apart.
- The phase search agrees with the independently written eclipse search about the 2026 new moon, to 11 minutes — the expected offset between conjunction in longitude and greatest *local* eclipse.

## Judgement calls

- **The sky gradient stays solar in every mode.** It's driven by sun altitude, and keeping it as the backdrop is what makes the moon's path readable — you can see whether the moon is up in darkness or wasted in daylight. It also gives "both" a clean meaning.
- **The moon is computed regardless of mode**, so switching shows data immediately rather than after a round trip. It costs a few hundred microseconds off the main thread, once per day and place.
- **Moon altitude samples use the existing `SkyRenderCache` pattern rather than `.task`** — the share card renders this chart through `ImageRenderer`, which never runs the view lifecycle, so anything task-driven would come out blank there.

## Not verified

No Swift toolchain in the session, so **none of this has been compiled or run** — the validation above is via a line-for-line Python port of the same algorithms. Worth a close look on first build:

- The five new SF Symbols (`moonrise`, `moonset`, `moonphase.*`) render as blank space rather than failing the build if a name is wrong.
- `SolsticeTests` has never executed in CI — both checks on #166 are archive actions.

## Follow-up

PR 2 will add the phase calendar replacing the annual chart in lunar mode. Lunar eclipses are deliberately deferred.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR3DD68Nh3jRJ6H7z8fHn1)_