### PR TITLE
Add manual drag-and-drop reordering for saved locations

### DIFF
--- a/Data Model/SavedLocation++.swift
+++ b/Data Model/SavedLocation++.swift
@@ -5,6 +5,7 @@
 //  Created by Daniel Eden on 04/07/2024.
 //
 
+import CoreData
 import Foundation
 
 extension SavedLocation {
@@ -19,6 +20,17 @@ extension SavedLocation {
 			timeZoneIdentifier: timeZoneIdentifier,
 			uuid: uuid
 		)
+	}
+}
+
+extension SavedLocation {
+	/// The index that places a new location at the end of the manual order.
+	static func nextSortIndex(in context: NSManagedObjectContext) -> Int64 {
+		let request = SavedLocation.fetchRequest()
+		request.sortDescriptors = [NSSortDescriptor(keyPath: \SavedLocation.sortIndex, ascending: false)]
+		request.fetchLimit = 1
+		let highest = (try? context.fetch(request))?.first?.sortIndex ?? -1
+		return highest + 1
 	}
 }
 

--- a/Data Model/Solstice.xcdatamodeld/.xccurrentversion
+++ b/Data Model/Solstice.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Solstice.xcdatamodel</string>
+	<string>Solstice 2.xcdatamodel</string>
 </dict>
 </plist>

--- a/Data Model/Solstice.xcdatamodeld/Solstice 2.xcdatamodel/contents
+++ b/Data Model/Solstice.xcdatamodeld/Solstice 2.xcdatamodel/contents
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="23G93" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
+    <entity name="SavedLocation" representedClassName="SavedLocation" syncable="YES" codeGenerationType="class">
+        <attribute name="latitude" attributeType="Double" defaultValueString="51.509865" usesScalarValueType="YES"/>
+        <attribute name="longitude" attributeType="Double" defaultValueString="-0.118092" usesScalarValueType="YES"/>
+        <attribute name="sortIndex" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="subtitle" optional="YES" attributeType="String"/>
+        <attribute name="timeZoneIdentifier" optional="YES" attributeType="String" defaultValueString="GMT"/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
+</model>

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -6742,6 +6742,64 @@
         }
       }
     },
+    "Manual" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "يدوي"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Manuell"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Manual"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Manuel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Manuale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "手動"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Handmatig"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "Ręcznie"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "machine_translated",
+            "value" : "手动"
+          }
+        }
+      }
+    },
     "March" : {
       "localizations" : {
         "ar" : {

--- a/Solstice.xcodeproj/project.pbxproj
+++ b/Solstice.xcodeproj/project.pbxproj
@@ -1874,7 +1874,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Solstice uses your location to calculate local sunrise and sunset times";
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.3.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1936,7 +1936,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Solstice uses your location to calculate local sunrise and sunset times";
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 3.2.0;
+				MARKETING_VERSION = 3.3.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/Solstice.xcodeproj/project.pbxproj
+++ b/Solstice.xcodeproj/project.pbxproj
@@ -481,6 +481,7 @@
 		7198468B28E5895F00E866CE /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		7198468D28E5895F00E866CE /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		7198469028E5895F00E866CE /* Solstice.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Solstice.xcdatamodel; sourceTree = "<group>"; };
+		7198469A2E67F1A200E866CE /* Solstice 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Solstice 2.xcdatamodel"; sourceTree = "<group>"; };
 		7198469228E5895F00E866CE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7198469828E5898500E866CE /* StoreKitConfiguration.storekit */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = StoreKitConfiguration.storekit; sourceTree = "<group>"; };
 		7198469D28E58CCD00E866CE /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
@@ -2263,9 +2264,10 @@
 		7198468F28E5895F00E866CE /* Solstice.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				7198469A2E67F1A200E866CE /* Solstice 2.xcdatamodel */,
 				7198469028E5895F00E866CE /* Solstice.xcdatamodel */,
 			);
-			currentVersion = 7198469028E5895F00E866CE /* Solstice.xcdatamodel */;
+			currentVersion = 7198469A2E67F1A200E866CE /* Solstice 2.xcdatamodel */;
 			path = Solstice.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Solstice/ContentView.swift
+++ b/Solstice/ContentView.swift
@@ -168,6 +168,9 @@ struct ContentView: View {
 		ToolbarItem(placement: .primaryAction) {
 			Menu {
 				Picker(selection: $itemSortDimension.animation()) {
+					Text("Manual")
+						.tag(Preferences.SortingFunction.manual)
+
 					Text("Timezone")
 						.tag(Preferences.SortingFunction.timezone)
 
@@ -177,14 +180,18 @@ struct ContentView: View {
 					Text("Sort by")
 				}
 
-				Picker(selection: $itemSortOrder.animation()) {
-					Text("Ascending")
-						.tag(SortOrder.forward)
+				// A manual order is whatever the user dragged it into; reversing it
+				// would only make the next drag land somewhere unexpected.
+				if itemSortDimension != .manual {
+					Picker(selection: $itemSortOrder.animation()) {
+						Text("Ascending")
+							.tag(SortOrder.forward)
 
-					Text("Descending")
-						.tag(SortOrder.reverse)
-				} label: {
-					Text("Order")
+						Text("Descending")
+							.tag(SortOrder.reverse)
+					} label: {
+						Text("Order")
+					}
 				}
 			} label: {
 				Label("Sort locations", systemImage: "arrow.up.arrow.down")

--- a/Solstice/Extensions/AppStorage++.swift
+++ b/Solstice/Extensions/AppStorage++.swift
@@ -121,6 +121,8 @@ enum Preferences {
 	// MARK: Appearance
 
 	enum SortingFunction: String, Codable, RawRepresentable {
+		/// The user's own drag-and-drop order, persisted as `SavedLocation.sortIndex`.
+		case manual
 		case timezone, daylightDuration
 	}
 

--- a/Solstice/Helpers/AnyLocation.swift
+++ b/Solstice/Helpers/AnyLocation.swift
@@ -62,6 +62,7 @@ final class TemporaryLocation: ObservableLocation {
 		savedLocation.timeZoneIdentifier = timeZoneIdentifier
 		savedLocation.longitude = longitude
 		savedLocation.latitude = latitude
+		savedLocation.sortIndex = SavedLocation.nextSortIndex(in: context)
 
 		try context.save()
 		return savedLocation.uuid

--- a/Solstice/List View/SidebarListView.swift
+++ b/Solstice/List View/SidebarListView.swift
@@ -61,10 +61,12 @@ struct SidebarListView: View {
 	/// The daylight-duration sort constructs an `NTSolar` per comparison, so
 	/// re-running it on every body evaluation is expensive. Recompute only when
 	/// an input that actually affects the order changes; `timeMachine.date` only
-	/// matters for the daylight-duration dimension.
+	/// matters for the daylight-duration dimension. `sortIndex` is included so a
+	/// reorder synced in from another device re-sorts the manual order.
 	private var sortSignature: SortSignature {
 		SortSignature(
 			ids: items.map(\.objectID),
+			sortIndices: items.map(\.sortIndex),
 			dimension: itemSortDimension,
 			order: itemSortOrder,
 			date: itemSortDimension == .daylightDuration ? timeMachine.date : nil
@@ -73,6 +75,7 @@ struct SidebarListView: View {
 
 	private struct SortSignature: Equatable {
 		let ids: [NSManagedObjectID]
+		let sortIndices: [Int64]
 		let dimension: Preferences.SortingFunction
 		let order: SortOrder
 		let date: Date?
@@ -111,6 +114,7 @@ struct SidebarListView: View {
 			savedLocationRow(for: item)
 		}
 		.onDelete(perform: deleteItems)
+		.onMove(perform: moveItems)
 	}
 
 	@ViewBuilder
@@ -186,6 +190,13 @@ extension SidebarListView {
 	private func recomputeSortedItems() {
 		sortedItems = items.sorted { lhs, rhs in
 			switch itemSortDimension {
+			case .manual:
+				// Locations that have never been dragged share index 0, so fall back
+				// to the fetch order (title) to keep the sort stable.
+				if lhs.sortIndex != rhs.sortIndex {
+					return lhs.sortIndex < rhs.sortIndex
+				}
+				return (lhs.title ?? "") < (rhs.title ?? "")
 			case .timezone:
 				switch itemSortOrder {
 				case .forward:
@@ -206,6 +217,29 @@ extension SidebarListView {
 				case .reverse:
 					return lhsSolar.daylightDuration > rhsSolar.daylightDuration
 				}
+			}
+		}
+	}
+
+	/// Persists a drag-and-drop reorder. Dragging in any sort mode adopts the
+	/// on-screen order as the new manual order and switches to it, so the row
+	/// stays where the user dropped it instead of snapping back.
+	private func moveItems(from source: IndexSet, to destination: Int) {
+		var reordered = sortedItems
+		reordered.move(fromOffsets: source, toOffset: destination)
+
+		withAnimation {
+			for (index, item) in reordered.enumerated() where item.sortIndex != Int64(index) {
+				item.sortIndex = Int64(index)
+			}
+
+			sortedItems = reordered
+			itemSortDimension = .manual
+
+			do {
+				try viewContext.save()
+			} catch {
+				print(error)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Adds support for manual drag-and-drop reordering of saved locations. Users can now reorder locations by dragging them in the sidebar, with the order persisted to Core Data and synced across devices via CloudKit.

## Key Changes
- **New sorting mode**: Added `.manual` case to `Preferences.SortingFunction` enum, allowing users to sort by their custom drag-and-drop order
- **Data model migration**: Created `Solstice 2.xcdatamodel` with new `sortIndex` attribute on `SavedLocation` to persist manual ordering
- **Drag-and-drop implementation**: 
  - Added `.onMove()` modifier to `SidebarListView` to enable row reordering
  - Implemented `moveItems()` method that persists reorder operations and automatically switches to manual sort mode
  - Added `nextSortIndex()` helper to assign sort indices to newly created locations
- **Sort signature tracking**: Updated `SortSignature` to include `sortIndices` so reorders synced from other devices trigger re-sorting
- **UI updates**:
  - Added "Manual" option to the sort picker in `ContentView`
  - Hidden the sort order picker when manual mode is active (since reversing a manual order would be unexpected)
- **Localization**: Added "Manual" string with machine translations for 9 languages (Arabic, German, Spanish, French, Italian, Japanese, Dutch, Polish, Simplified Chinese)
- **Version bump**: Updated marketing version from 3.2.0 to 3.3.0

## Implementation Details
- Manual sort falls back to title-based ordering for locations that haven't been dragged (both have `sortIndex` of 0) to maintain stable sorting
- Dragging in any sort mode adopts the on-screen order as the new manual order and switches to it, preventing the row from snapping back
- The sort signature now includes sort indices to ensure CloudKit syncs of reorders from other devices trigger proper re-sorting

https://claude.ai/code/session_01SuVkpBmDxf4SmS9XbMh4Jf